### PR TITLE
Frequency no longer in last dim

### DIFF
--- a/src/freqresp.jl
+++ b/src/freqresp.jl
@@ -138,7 +138,7 @@ function sigma(sys::LTISystem, w::AbstractVector)
     nw, ny, nu = size(resp)
     sv = Array(Float64, nw, min(ny, nu))
     for i=1:nw
-        sv[i, :] = svdvals(resp[i, :, :])
+        sv[i, :] = svdvals(squeeze(resp[i, :, :],(1)))
     end
     return sv, w
 end

--- a/src/pid_design.jl
+++ b/src/pid_design.jl
@@ -224,7 +224,7 @@ If `P` is a string (e.g. "exp(-sqrt(s))", the stability of feedback loops using 
 See also `stabregionPID`, `loopshapingPI`, `pidplots`
 """
 function stabregionPID(P, ω = _default_freq_vector(P,:bode); kd=0, doplot = true)
-    Pv      = squeeze(freqresp(P,ω)[1],(1,2))
+    Pv      = squeeze(freqresp(P,ω)[1],(2,3))
     r       = abs(Pv)
     phi     = angle(Pv)
     kp      = -cos(phi)./r

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -146,7 +146,7 @@ function bodeplot{T<:LTISystem}(systems::Vector{T}, w::AbstractVector; plotphase
                 end
                 phasedata = vec(phase[:, i, j])
                 Plots.plot!(fig[(plotphase?(2i-1):i),j], w, magdata, grid=true, yscale=_PlotScaleFunc, xscale=:log10, xlabel=xlab, title="Bode plot from: u($j)", ylabel="Magnitude $_PlotScaleStr", lab="\$G_\{$(si)\}\$"; getStyleSys(si,length(systems))..., kwargs...)
-                plotphase && Plots.plot!(fig[2i,j], w, phasedata, grid=true, xscale=:log10, ylabel="Phase (deg)",xlabel="Frequency (rad/s)"; getStyleSys(si,length(systems))...)
+                plotphase && Plots.plot!(fig[2i,j], w, phasedata, grid=true, xscale=:log10, ylabel="Phase (deg)",xlabel="Frequency (rad/s)"; getStyleSys(si,length(systems))..., kwargs...)
             end
         end
     end
@@ -357,7 +357,7 @@ function sigmaplot{T<:LTISystem}(systems::Vector{T}, w::AbstractVector; kwargs..
         if _PlotScale == "dB"
             sv = 20*log10(sv)
         end
-        for i in 1:size(sv, 1)
+        for i in 1:size(sv, 2)
             Plots.plot!(fig, w, sv[:, i], xscale=:log10, yscale=_PlotScaleFunc; getStyleSys(si,length(systems))..., kwargs...)
         end
     end

--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -6,7 +6,9 @@
 
 Calculate the step response of system `sys`. If the final time `Tf` or time
 vector `t` is not provided, one is calculated based on the system pole
-locations.""" ->
+locations.
+
+`y` has size `(length(t), ny, nu)`, `x` has size `(length(t), nx, nu)`""" ->
 function Base.step(sys::StateSpace, t::AbstractVector)
     lt = length(t)
     ny, nu = size(sys)
@@ -36,7 +38,9 @@ Base.step(sys::TransferFunction, t::AbstractVector) = step(ss(sys), t::AbstractV
 
 Calculate the impulse response of system `sys`. If the final time `Tf` or time
 vector `t` is not provided, one is calculated based on the system pole
-locations.""" ->
+locations.
+
+`y` has size `(length(t), ny, nu)`, `x` has size `(length(t), nx, nu)`""" ->
 function impulse(sys::StateSpace, t::AbstractVector)
     lt = length(t)
     ny, nu = size(sys)
@@ -79,6 +83,8 @@ impulse(sys::TransferFunction, t::AbstractVector) = impulse(ss(sys), t)
 
 Calculate the time response of system `sys` to input `u`. If `x0` is ommitted,
 a zero vector is used.
+
+`y`, `x`, `uout` has time in the first dimension.
 
 Continuous time systems are discretized before simulation. By default, the
 method is chosen based on the smoothness of the input signal. Optionally, the

--- a/test/test_freqresp.jl
+++ b/test/test_freqresp.jl
@@ -24,4 +24,11 @@ z = 0.5(1+im)
 @test F(omega,true)[1] == 1/(exp(-im*2)+0.5)
 @test F(z,false)[1] == 1/(z+0.5)
 @test_throws ErrorException F(z,true)
+
+sys = tf([1,-1], [1,1,1])
+f(s) = (s-1)./(s.^2+s+1)
+w = logspace(-2,2,50)
+resp = f(im*w)
+
+@test bode(sys, w)[1:2] == (abs(resp[:,:,:]), rad2deg(angle(resp[:,:,:])))
 end

--- a/test/test_timeresp.jl
+++ b/test/test_timeresp.jl
@@ -32,4 +32,40 @@ yd, td, xd = lsim(sysdfb, zeros(501), t, x0)
 @test_approx_eq y yd
 @test_approx_eq x xd
 
+
+#Test step and impulse
+t0 = 0:0.05:2
+systf = [tf(1,[1,1]) 0; 0 tf([1,-1],[1,2,1])]
+sysss = ss([-1 0 0; 0 -2 -1; 0 1 0], [1 0; 0 1; 0 0], [1 0 0; 0 1 -1], 0)
+yreal = zeros(length(t0), 2, 2)
+xreal = zeros(length(t0), 3, 2)
+
+#Step tf
+y, t, x = step(systf, t0)
+yreal[:,1,1] = 1-exp(-t)
+yreal[:,2,2] = -1+exp(-t)+2*exp(-t).*t
+@test_approx_eq_eps y yreal 1e-14
+#Step ss
+y, t, x = step(sysss, t)
+@test_approx_eq_eps y yreal 1e-14
+xreal[:,1,1] = yreal[:,1,1]
+xreal[:,2,2] = exp(-t).*t
+xreal[:,3,2] = exp(-t).*(-t-1) + 1
+@test_approx_eq_eps x xreal 1e-14
+
+#Impulse tf
+y, t, x = impulse(systf, t)
+yreal[:,1,1] = exp(-t)
+yreal[:,2,2] = exp(-t).*(1 - 2.*t)
+@test_approx_eq_eps y yreal 1e-14
+#Impulse ss
+y, t, x = impulse(sysss, t)
+@test_approx_eq_eps y yreal 1e-14
+xreal[:,1,1] = yreal[:,1,1]
+xreal[:,2,2] = -exp(-t).*t + exp(-t)
+xreal[:,3,2] = exp(-t).*t
+@test_approx_eq_eps x xreal 1e-14
+
+#Make sure t was never changed
+@test t0 == t
 end


### PR DESCRIPTION
Fixing the problem with frequencies begin added in the last dim #17 instead of first in frequency responses. Also added several good tests for time and frequency domain. We should not pull this until we have used it for a while since it contains many changes, but feel free to look through my changes @baggepinnen.

Should also fix #39.