### PR TITLE
Fix `dcgain(sys::TransferFunction)` (addresses #15)

### DIFF
--- a/docs/src/examples/example.md
+++ b/docs/src/examples/example.md
@@ -1,7 +1,8 @@
-    {meta}
-    DocTestSetup = quote
-        using ControlSystems
-    end
+```@meta
+DocTestSetup = quote
+    using ControlSystems
+end
+```
 
 # PID design functions
 By plotting the gang of four under unit feedback for the process

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,26 +1,31 @@
 # ControlSystems.jl Manual
 
-    {meta}
-    CurrentModule = ControlSystems
+```@meta
+CurrentModule = ControlSystems
+```
 
 ## Examples
-    {contents}
-    Pages = ["examples/example.md"]
-    Depth = 1
+```@contents
+Pages = ["examples/example.md"]
+Depth = 1
+```
 
 ## Guide
 
-    {contents}
-    Pages = ["man/introduction.md", "man/creatingtfs.md"]
-    Depth = 1
+```@contents
+Pages = ["man/introduction.md", "man/creatingtfs.md"]
+Depth = 1
+```
 
 ## Functions
 
-    {contents}
-    Pages = ["lib/constructors.md", "lib/plotting.md"]
+```@contents
+Pages = ["lib/constructors.md", "lib/plotting.md"]
+```
 
 ## Documentation Index
 
-    {index}
-    Pages = ["lib/constructors.md", "lib/plotting.md", "lib/syntheis.md", "lib/timefreqresponse.md", "lib/analysis.md"]
-    Depth = 1
+```@index
+Pages = ["lib/constructors.md", "lib/plotting.md", "lib/syntheis.md", "lib/timefreqresponse.md", "lib/analysis.md"]
+Depth = 1
+```

--- a/docs/src/lib/analysis.md
+++ b/docs/src/lib/analysis.md
@@ -1,24 +1,26 @@
-    {index}
-    Pages = ["analysis.md"]
+```@index
+Pages = ["analysis.md"]
+```
 
 # Analysis
 
-    {docs}
-    covar
-    ctrb
-    damp
-    dampreport
-    dcgain
-    delaymargin
-    gangoffour
-    gangofseven
-    gram
-    margin
-    markovparam
-    norm
-    obsv
-    pole
-    sigma
-    stabregionPID
-    tzero
-    zpkdata
+```@docs
+covar
+ctrb
+damp
+dampreport
+dcgain
+delaymargin
+gangoffour
+gangofseven
+gram
+margin
+markovparam
+norm
+obsv
+pole
+sigma
+stabregionPID
+tzero
+zpkdata
+```

--- a/docs/src/lib/constructors.md
+++ b/docs/src/lib/constructors.md
@@ -1,19 +1,21 @@
-    {index}
-    Pages = ["constructors.md"]
+```@index
+Pages = ["constructors.md"]
+```
 
 # Constructing transfer functions
 
-    {docs}
-    append
-    c2d
-    feedback
-    feedback2dof
-    minreal
-    parallel
-    series
-    sminreal
-    ss
-    ss2tf
-    tf
-    tfg
-    zpk
+```@docs
+append
+c2d
+feedback
+feedback2dof
+minreal
+parallel
+series
+sminreal
+ss
+ss2tf
+tf
+tfg
+zpk
+```

--- a/docs/src/lib/plotting.md
+++ b/docs/src/lib/plotting.md
@@ -1,21 +1,23 @@
-    {index}
-    Pages = ["plotting.md"]
+```@index
+Pages = ["plotting.md"]
+```
 
 # Plotting functions
 
-    {docs}
-    bodeplot
-    gangoffourplot
-    impulseplot
-    leadlinkcurve
-    lsimplot
-    marginplot
-    nicholsplot
-    nyquistplot
-    pidplots
-    pzmap
-    pzmap!
-    rlocus
-    sigmaplot
-    setPlotScale
-    stepplot
+```@docs
+bodeplot
+gangoffourplot
+impulseplot
+leadlinkcurve
+lsimplot
+marginplot
+nicholsplot
+nyquistplot
+pidplots
+pzmap
+pzmap!
+rlocus
+sigmaplot
+setPlotScale
+stepplot
+```

--- a/docs/src/lib/synthesis.md
+++ b/docs/src/lib/synthesis.md
@@ -1,24 +1,26 @@
-    {index}
-    Pages = ["synthesis.md"]
+```@index
+Pages = ["synthesis.md"]
+```
 
 # Synthesis
 
-    {docs}
-    balance
-    care
-    dab
-    dare
-    dkalman
-    dlqr
-    dlyap
-    kalman
-    laglink
-    leadlink
-    leadlinkat
-    loopshapingPI
-    lqr
-    pid
-    place
-    reduce_sys
-    rstc
-    rstd
+```@docs
+balance
+care
+dab
+dare
+dkalman
+dlqr
+dlyap
+kalman
+laglink
+leadlink
+leadlinkat
+loopshapingPI
+lqr
+pid
+place
+reduce_sys
+rstc
+rstd
+```

--- a/docs/src/lib/timefreqresponse.md
+++ b/docs/src/lib/timefreqresponse.md
@@ -1,14 +1,16 @@
-    {index}
-    Pages = ["timefreqresponse.md"]
+```@index
+Pages = ["timefreqresponse.md"]
+```
 
 # Time and Frequency response
 
-    {docs}
-    call
-    bode
-    evalfr
-    freqresp
-    impulse
-    lsim
-    nyquist
-    step
+```@docs
+call
+bode
+evalfr
+freqresp
+impulse
+lsim
+nyquist
+step
+```

--- a/docs/src/man/creatingtfs.md
+++ b/docs/src/man/creatingtfs.md
@@ -1,8 +1,9 @@
 # Creating Transfer Functions
-    {meta}
-    DocTestSetup = quote
-        using ControlSystems
-    end
+```@meta
+DocTestSetup = quote
+    using ControlSystems
+end
+```
 
 ## tf - Rational Representation
 The syntax for creating a transfer function is

--- a/docs/src/man/introduction.md
+++ b/docs/src/man/introduction.md
@@ -7,13 +7,14 @@ Pkg.add("ControlSystems")
 ```
 
 ## Basic functions
-    {meta}
-    DocTestSetup = quote
-        using ControlSystems
-        P = tf([1],[1,1])
-        T = P/(1+P)
-    end
-Transfer functions can easily be created using the function `tf(num, den, Ts=0)`, where `num` and `den` are vectors representing the numerator and denominator of a rational function. See [`tf`]({ref}) or the section "Creating Transfer Functions" for more info. These functions can then be connected and modified using the operators `+,-,*,/` and functions like [`append`]({ref}).
+```@meta
+DocTestSetup = quote
+    using ControlSystems
+    P = tf([1],[1,1])
+    T = P/(1+P)
+end
+```
+Transfer functions can easily be created using the function `tf(num, den, Ts=0)`, where `num` and `den` are vectors representing the numerator and denominator of a rational function. See [`tf`](@ref) or the section "Creating Transfer Functions" for more info. These functions can then be connected and modified using the operators `+,-,*,/` and functions like [`append`](@ref).
 
 Example:
 ```julia

--- a/src/ControlSystems.jl
+++ b/src/ControlSystems.jl
@@ -60,7 +60,9 @@ export  LTISystem,
         sigma,
         # utilities
         numpoly,
-        denpoly
+        denpoly,
+        numvec,
+        denvec
 
 import Plots
 import Base: +, -, *, /, (./), (==), (.+), (.-), (.*), (!=), isapprox, call, convert

--- a/src/synthesis.jl
+++ b/src/synthesis.jl
@@ -175,7 +175,7 @@ end
 """
 function feedback2dof(P::TransferFunction,R,S,T)
     !issiso(P) && error("Feedback not implemented for MIMO systems")
-    tf(conv(poly2vec(numpoly(P)[1]),T),zpconv(poly2vec(denpoly(P)[1]),R,poly2vec(numpoly(P)[1]),S))
+    feedback2dof(numvec(P)[1], denvec(P)[1], R, S, T)
  end
 
 feedback2dof(B,A,R,S,T) = tf(conv(B,T),zpconv(A,R,B,S))

--- a/src/types/polys.jl
+++ b/src/types/polys.jl
@@ -200,6 +200,8 @@ function polyval{T}(p::Poly{T}, x::Number)
     end
 end
 
+Base.call{T}(p::Poly{T}, x::Number) = polyval(p, x)
+
 # compute the roots of a polynomial
 function roots{T}(p::Poly{T})
     R = promote_type(T, Float64)

--- a/src/types/sisogeneralized.jl
+++ b/src/types/sisogeneralized.jl
@@ -29,11 +29,7 @@ Base.convert(::Type{SisoGeneralized}, b::Real) = SisoGeneralized(b)
 Base.zero(::Type{SisoGeneralized}) = SisoGeneralized(0)
 Base.zero(::SisoGeneralized) = Base.zero(SisoGeneralized)
 
-Base.length(t::SisoGeneralized) = error("length is not implemented for generalized transferfunctions")
-Base.num(t::SisoGeneralized) = error("num is not implemented for generalized transferfunctions")
-Base.den(t::SisoGeneralized) = error("den is not implemented for generalized transferfunctions")
-pole(t::SisoGeneralized) = error("pole is not implemented for generalized transferfunctions")
-tzero(t::SisoGeneralized) = error("tzero is not implemented for generalized transferfunctions")
+Base.length(::SisoGeneralized) = error("length is not implemented for generalized transferfunctions")
 
 #This makes sure that the function can compile once
 function _preprocess_for_freqresp(sys::SisoGeneralized)

--- a/src/types/sisotf.jl
+++ b/src/types/sisotf.jl
@@ -9,7 +9,7 @@ immutable SisoRational <: SisoTf
             # The numerator is zero, make the denominator 1
             den = one(den)
         end
-        new(num, den)
+        new(copy(num), copy(den))
     end
 end
 SisoRational(num::Vector, den::Vector) = SisoRational(Poly(map(Float64,num)), Poly(map(Float64,den)))
@@ -54,6 +54,7 @@ Base.zero(::SisoRational) = Base.zero(SisoRational)
 Base.length(t::SisoRational) = max(length(t.num), length(t.den))
 
 function Base.num(t::SisoRational)
+    Base.depwarn("`num is deprecated for getting numerator, use `numvec` or `numpoly` instead", :numvec)
     lt = length(t)
     n = zeros(lt)
     n[(lt - length(t.num) + 1):end] = t.num[:]
@@ -61,22 +62,25 @@ function Base.num(t::SisoRational)
 end
 
 function Base.den(t::SisoRational)
+    Base.depwarn("`den` is deprecated for getting denominator, use `denvec` or `denpoly` instead", :denvec)
     lt = length(t)
     d = zeros(lt)
     d[(lt - length(t.den) + 1):end] = t.den[:]
     return d
 end
 
-denpoly(G::SisoRational) = Poly(den(G))
-numpoly(G::SisoRational) = Poly(num(G))
+numvec(t::SisoRational) = t.num[:]
+denvec(t::SisoRational) = t.den[:]
+numpoly(t::SisoRational) = copy(t.num)
+denpoly(t::SisoRational) = copy(t.den)
 
 function evalfr(sys::SisoRational, s::Number)
     S = promote_type(typeof(s), Float64)
-    den = polyval(sys.den, s)
+    den = sys.den(s)
     if den == zero(S)
         convert(S, Inf)
     else
-        polyval(sys.num, s)/den
+        sys.num(s)/den
     end
 end
 

--- a/src/types/sisotf.jl
+++ b/src/types/sisotf.jl
@@ -51,7 +51,7 @@ Base.convert(::Type{SisoRational}, b::Real) = SisoRational([b], [1])
 Base.zero(::Type{SisoRational}) = SisoRational(zero(Poly{Float64}), one(Poly{Float64}))
 Base.zero(::SisoRational) = Base.zero(SisoRational)
 
-Base.length(t::SisoRational) = max(length(t.num), length(t.den))
+Base.length(t::SisoRational) = max(length(t.num), length(t.den)) - 1
 
 function Base.num(t::SisoRational)
     Base.depwarn("`num is deprecated for getting numerator, use `numvec` or `numpoly` instead", :numvec)

--- a/src/types/sisotf.jl
+++ b/src/types/sisotf.jl
@@ -69,7 +69,7 @@ function Base.den(t::SisoRational)
     return d
 end
 
-numvec(t::SisoRational) = t.num[:]
+numvec(t::SisoRational) = vcat(zeros(length(t)-length(t.num)), t.num[:])
 denvec(t::SisoRational) = t.den[:]
 numpoly(t::SisoRational) = copy(t.num)
 denpoly(t::SisoRational) = copy(t.den)

--- a/src/types/sisozpk.jl
+++ b/src/types/sisozpk.jl
@@ -88,7 +88,10 @@ function zp2polys(vec)
     polys
 end
 
-numvec(t::SisoZpk) = numpoly(t)[:]
+function numvec(t::SisoZpk)
+  np = numpoly(t)
+  vcat(zeros(length(t)-length(np)), np[:])
+end
 denvec(t::SisoZpk) = denpoly(t)[:]
 
 numpoly(t::SisoZpk) = prod(zp2polys(t.z))*t.k

--- a/src/types/sisozpk.jl
+++ b/src/types/sisozpk.jl
@@ -57,15 +57,17 @@ function minreal(sys::SisoZpk, eps::Real)
 end
 
 function Base.num(t::SisoZpk)
+    Base.depwarn("`num is deprecated for getting numerator, use `numvec` or `numpoly` instead", :numvec)
     return copy(t.z)
 end
 
 function Base.den(t::SisoZpk)
+    Base.depwarn("`den is deprecated for getting denominator, use `denvec` or `denpoly` instead", :denvec)
     return copy(t.p)
 end
 
-tzero(sys::SisoZpk) = num(sys)
-pole(sys::SisoZpk) = den(sys)
+tzero(sys::SisoZpk) = copy(sys.z)
+pole(sys::SisoZpk) = copy(sys.p)
 
 function zp2polys(vec)
     polys = Array{Poly{Float64},1}(0)
@@ -86,13 +88,11 @@ function zp2polys(vec)
     polys
 end
 
-function numpoly(G::SisoZpk)
-    zpolys = zp2polys(G.z)
-end
+numvec(t::SisoZpk) = numpoly(t)[:]
+denvec(t::SisoZpk) = denpoly(t)[:]
 
-function denpoly(G::SisoZpk)
-    ppolys = zp2polys(G.p)
-end
+numpoly(t::SisoZpk) = prod(zp2polys(t.z))*t.k
+denpoly(t::SisoZpk) = prod(zp2polys(t.p))
 
 function evalfr(sys::SisoZpk, s::Number)
     S = promote_type(typeof(s), Float64)

--- a/src/types/tf2ss.jl
+++ b/src/types/tf2ss.jl
@@ -43,13 +43,15 @@ siso_tf_to_ss(t::SisoTf) = siso_tf_to_ss(convert(SisoRational, t))
 
 function siso_tf_to_ss(t::SisoRational)
     t = normalize_tf(t)
-    tnum = num(t)
-    tden = den(t)
+    tnum0 = numvec(t)
+    tden = denvec(t)
     len = length(tden)
+    #Pad tnum0 with zeros
+    tnum = [zeros(len - length(tnum0)); tnum0]
     d = Array(Float64, 1, 1)
     d[1] = tnum[1]
 
-    if len==1 || tnum == zero(Poly{Float64})
+    if len==1 || tnum == [0.0]
         a = zeros(0, 0)
         b = zeros(0, 1)
         c = zeros(1, 0)
@@ -63,8 +65,10 @@ function siso_tf_to_ss(t::SisoRational)
 end
 
 function normalize_tf(t::SisoRational)
-    d = t.den[1]
-    return SisoTf(t.num/d, t.den/d)
+    num = numpoly(t)
+    den = denpoly(t)
+    d = denvec(t)[1]
+    return SisoTf(num/d, den/d)
 end
 
 

--- a/src/types/transferfunction.jl
+++ b/src/types/transferfunction.jl
@@ -353,7 +353,7 @@ denpoly{T<:SisoTf}(::T) = error("denpoly is not implemented for type $T")
 """
 `numpolys = numpoly(tf::TransferFunction)`
 
-Get an `Array` of of size `(ny,nu)` containing `Poly`s representing the
+Get an `Array` of size `(ny,nu)` containing `Poly`s representing the
 numerators of `tf` from each input to output.
 
 The numerators from `numpoly` divided by the denominators in `denpoly`
@@ -366,7 +366,7 @@ numpoly(t::TransferFunction) = map(numpoly, t.matrix)
 """
 `denpolys = denpoly(tf::TransferFunction)`
 
-Get an `Array` of of size `(ny,nu)` containing `Poly`s representing the
+Get an `Array` of size `(ny,nu)` containing `Poly`s representing the
 denominators of `tf` from each input to output.
 
 The numerators from `numpoly` divided by the denominators in `denpoly`
@@ -379,7 +379,7 @@ denpoly(t::TransferFunction) = map(denpoly, t.matrix)
 """
 `numvecs = numvec(tf::TransferFunction)`
 
-Get an `Array` of of size `(ny,nu)` containing `Vector`s representing the
+Get an `Array` of size `(ny,nu)` containing `Vector`s representing the
 numerators of `tf` from each input to output.
 
 The numerators from `numpoly` divided by the denominators in `denpoly`
@@ -395,7 +395,7 @@ numvec(t::TransferFunction) = map(numvec, t.matrix)
 """
 `denvecs = denvec(tf::TransferFunction)`
 
-Get an `Array` of of size `(ny,nu)` containing `Vector`s representing the
+Get an `Array` of size `(ny,nu)` containing `Vector`s representing the
 denominators of `tf` from each input to output.
 
 The numerators from `numpoly` divided by the denominators in `denpoly`

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -38,7 +38,7 @@ Returns `true` if the `TransferFunction` is proper. This means that order(den)
 \>= order(num))""" ->
 function isproper(t::TransferFunction)
     for s in t.matrix
-        if length(num(s)) > length(den(s))
+        if length(numpoly(s)) > length(denpoly(s))
             return false
         end
     end
@@ -99,9 +99,5 @@ end
 #Collect will create a copy and collect the elements
 unwrap(m::AbstractArray, args...) = unwrap!(collect(m), args...)
 unwrap(x::Number) = x
-
-
-numpoly(G::TransferFunction) = map(numpoly, G.matrix)
-denpoly(G::TransferFunction) = map(denpoly, G.matrix)
 
 poly2vec(p::Poly) = p.a[1:end]

--- a/test/test_analysis.jl
+++ b/test/test_analysis.jl
@@ -137,7 +137,6 @@ z, p, k = zpkdata(G)
 ## GAIN ## #Gain is confusing when referring to zpkdata. Test dcgain instead
 @test [dcgain(H[1, 1]) dcgain(H[1, 2]); dcgain(H[2, 1]) dcgain(H[2, 2])] ≈ [0 0; 0.2 1/3]
 @test [dcgain(G[1, 1]) dcgain(G[1, 2]); dcgain(G[2, 1]) dcgain(G[2, 2])] ≈ [0 0; 0.2 1/3]
-@test_err dcgain(H)
 @test_err dcgain(G)
 
 ## MARKOVPARAM ##

--- a/test/test_generalizedtf.jl
+++ b/test/test_generalizedtf.jl
@@ -15,4 +15,20 @@ C_111 = tfg("(s+1)/(s+2)")
 @test zpk(C_011*C_111) == zpk([-1,-2],[-2],1)
 
 @test bode(C_111*C_011, logspace(-1,1)) == bode(tfg("(s+2)*((s+1)/(s+2))"), logspace(-1,1))
+
+# Test numpoly, numvec, denpoly, denvec for SisoZpk
+
+# Test deprecation (is not an error)
+#@test_err num(C_111.matrix[1,1])
+#@test_err den(C_111.matrix[1,1])
+
+@test_err numvec(C_111.matrix[1,1])
+@test_err denvec(C_111.matrix[1,1])
+
+@test_err numvec(C_111)
+@test_err denvec(C_111)
+
+@test_err numpoly(C_111)
+@test_err denpoly(C_111)
+
 end

--- a/test/test_matrix_comps.jl
+++ b/test/test_matrix_comps.jl
@@ -22,4 +22,20 @@ Ab,Bb,Cb,T = ControlSystems.balance_statespace(A,B,C)
 
 @test_approx_eq ControlSystems.balance_transform(A,B,C) ControlSystems.balance_transform(sys)
 
+W = eye(2)
+@test_approx_eq covar(sys, W) [0.002560975609756 0.002439024390244; 0.002439024390244 0.002560975609756]
+D2 = eye(2)
+@test_approx_eq covar(ss(A,B,C,D2, 1), W) [1.000110108378310 -0.000010098377310; -0.000010098377310 1.000110108378310]
+# Direct term means infinite covariance
+@test_approx_eq covar(ss(A,B,C,D2), W) [Inf Inf; Inf Inf]
+
+# No noise on second output should give finite variance
+@test_approx_eq covar(ss(A,B,C,[1 0; 0 0]), W) [Inf Inf; Inf 0.002560975609756]
+
+# Unstable system has inf covar
+@test covar(ss(eye(2),B,C,0), W) == [Inf Inf; Inf Inf]
+
+# Discrete system can have direct term
+@test_approx_eq covar(ss(A,B,C,D2,0.1),W) [1.00011010837831 -1.0098377309782909e-5; -1.0098377309782909e-5 1.00011010837831]
+
 end

--- a/test/test_plots.jl
+++ b/test/test_plots.jl
@@ -6,6 +6,9 @@ using VisualRegressionTests, ControlExamplePlots
 default(show=false)
 
 funcs, refs, eps = getexamples()
+# Make it easier to pass tests on different systems
+# Set to a factor 2 of common errors
+eps = [0.15, 0.015, 0.1, 0.01, 0.01, 0.02, 0.01, 0.15, 0.15, 0.01]
 res = genplots(funcs, refs, eps=eps, popup=false)
 
 ##Explicit enumeration for simpler debugging

--- a/test/test_transferfunction.jl
+++ b/test/test_transferfunction.jl
@@ -129,4 +129,28 @@ D_diffTs = tf([1], [2], 0.1)
 @test_err tf("z", 0)                # z creation can't be continuous
 @test_err tf("z")                   # z creation can't be continuous
 @test_err [z 0]                     # Sampling time mismatch (inferec could be implemented)
+
+# Test numpoly, numvec, denpoly, denvec for SisoRational
+
+# Test deprecation (is not an error)
+#@test_err num(C_111.matrix[1,1])
+#@test_err den(C_111.matrix[1,1])
+
+@test numvec(C_111.matrix[1,1]) == [1, 2]
+@test denvec(C_111.matrix[1,1]) == [1, 5]
+
+vecs = Array{Array{Float64,1},2}(1,2)
+vecs[1,1] = [1,2,3]; vecs[1,2] = [1, 2]
+@test numvec(D_221) == vecs
+vecs[1,1] = [1,-0.2,-0.15]; vecs[1,2] = [1, -0.2, -0.15]
+@test denvec(D_221) == vecs
+
+@test size(numpoly(D_221)) == (1,2)
+@test numpoly(D_221) == [ControlSystems.Poly([1, 2, 3.0]) ControlSystems.Poly([1, 2.0])]
+@test size(denpoly(D_221)) == (1,2)
+@test denpoly(D_221) == [ControlSystems.Poly([1, -0.2, -0.15]) ControlSystems.Poly([1, -0.2, -0.15])]
+
+#After switch to polynomials
+#@test numpoly(D_221) == [Polynomials.Poly([3.0, 2, 1]) Polynomials.Poly([2.0, 1])])
+#@test denpoly(D_221) == [Polynomials.Poly([-0.15, -0.2, 1]) Polynomials.Poly([-0.15, -0.2, 1])]
 end

--- a/test/test_zpk.jl
+++ b/test/test_zpk.jl
@@ -110,4 +110,35 @@ D_diffTs = zpk(tf([1], [2], 0.1))
 @test_err zpk("z")                   # z creation can't be continuous
 # Remove this when inferec is implemented
 @test_err [z 0]                     # Sampling time mismatch (inferec could be implemented)
+
+# Test numpoly, numvec, denpoly, denvec for SisoZpk
+
+# Test deprecation
+#@test_err num(C_111.matrix[1,1])
+#@test_err den(C_111.matrix[1,1])
+
+@test numvec(C_111.matrix[1,1]) == [1, 2]
+@test denvec(C_111.matrix[1,1]) == [1, 5]
+
+#Unwrap matrix to use approx_eq
+@test_approx_eq numvec(D_221)[1,1] [1, 2, 3]
+@test_approx_eq numvec(D_221)[1,2] [1, 2]
+
+@test_approx_eq denvec(D_221)[1,1] [1,-0.2,-0.15]
+@test_approx_eq denvec(D_221)[1,2] [1, -0.2, -0.15]
+
+@test size(numpoly(D_221)) == (1,2)
+@test numpoly(D_221)[1,1] ≈ ControlSystems.Poly([1,2,3.0])
+@test numpoly(D_221)[1,2] ≈ ControlSystems.Poly([1, 2.0])
+
+@test size(denpoly(D_221)) == (1,2)
+@test denpoly(D_221)[1,1] ≈ ControlSystems.Poly([1, -0.2, -0.15])
+@test denpoly(D_221)[1,2] ≈ ControlSystems.Poly([1, -0.2, -0.15])
+
+#After switch to polynomials
+#@test numpoly(D_221)[1,1] ≈ Polynomials.Poly([3.0, 2, 1])
+#@test numpoly(D_221)[1,2] ≈ Polynomials.Poly([2.0, 1])
+
+#@test denpoly(D_221) ≈ Polynomials.Poly([-0.15, -0.2, 1])
+#@test denpoly(D_221) ≈ Polynomials.Poly([-0.15, -0.2, 1])
 end


### PR DESCRIPTION
Fixed the function definition of `dcgain` for `sys::TransferFunction` type
inputs. Added documentation accordingly. Seems to be working fine with the
provided example set.
