### PR TITLE
Deprecated num/den for numvec,numpoly...

### DIFF
--- a/src/ControlSystems.jl
+++ b/src/ControlSystems.jl
@@ -60,7 +60,9 @@ export  LTISystem,
         sigma,
         # utilities
         numpoly,
-        denpoly
+        denpoly,
+        numvec,
+        denvec
 
 import Plots
 import Base: +, -, *, /, (./), (==), (.+), (.-), (.*), (!=), isapprox, call, convert

--- a/src/synthesis.jl
+++ b/src/synthesis.jl
@@ -175,7 +175,7 @@ end
 """
 function feedback2dof(P::TransferFunction,R,S,T)
     !issiso(P) && error("Feedback not implemented for MIMO systems")
-    tf(conv(poly2vec(numpoly(P)[1]),T),zpconv(poly2vec(denpoly(P)[1]),R,poly2vec(numpoly(P)[1]),S))
+    feedback2dof(numvec(P)[1], denvec(P)[1], R, S, T)
  end
 
 feedback2dof(B,A,R,S,T) = tf(conv(B,T),zpconv(A,R,B,S))

--- a/src/types/polys.jl
+++ b/src/types/polys.jl
@@ -200,6 +200,8 @@ function polyval{T}(p::Poly{T}, x::Number)
     end
 end
 
+Base.call{T}(p::Poly{T}, x::Number) = polyval(p, x)
+
 # compute the roots of a polynomial
 function roots{T}(p::Poly{T})
     R = promote_type(T, Float64)

--- a/src/types/sisogeneralized.jl
+++ b/src/types/sisogeneralized.jl
@@ -29,11 +29,7 @@ Base.convert(::Type{SisoGeneralized}, b::Real) = SisoGeneralized(b)
 Base.zero(::Type{SisoGeneralized}) = SisoGeneralized(0)
 Base.zero(::SisoGeneralized) = Base.zero(SisoGeneralized)
 
-Base.length(t::SisoGeneralized) = error("length is not implemented for generalized transferfunctions")
-Base.num(t::SisoGeneralized) = error("num is not implemented for generalized transferfunctions")
-Base.den(t::SisoGeneralized) = error("den is not implemented for generalized transferfunctions")
-pole(t::SisoGeneralized) = error("pole is not implemented for generalized transferfunctions")
-tzero(t::SisoGeneralized) = error("tzero is not implemented for generalized transferfunctions")
+Base.length(::SisoGeneralized) = error("length is not implemented for generalized transferfunctions")
 
 #This makes sure that the function can compile once
 function _preprocess_for_freqresp(sys::SisoGeneralized)

--- a/src/types/sisotf.jl
+++ b/src/types/sisotf.jl
@@ -9,7 +9,7 @@ immutable SisoRational <: SisoTf
             # The numerator is zero, make the denominator 1
             den = one(den)
         end
-        new(num, den)
+        new(copy(num), copy(den))
     end
 end
 SisoRational(num::Vector, den::Vector) = SisoRational(Poly(map(Float64,num)), Poly(map(Float64,den)))
@@ -54,6 +54,7 @@ Base.zero(::SisoRational) = Base.zero(SisoRational)
 Base.length(t::SisoRational) = max(length(t.num), length(t.den))
 
 function Base.num(t::SisoRational)
+    Base.depwarn("`num is deprecated for getting numerator, use `numvec` or `numpoly` instead", :numvec)
     lt = length(t)
     n = zeros(lt)
     n[(lt - length(t.num) + 1):end] = t.num[:]
@@ -61,22 +62,25 @@ function Base.num(t::SisoRational)
 end
 
 function Base.den(t::SisoRational)
+    Base.depwarn("`den` is deprecated for getting denominator, use `denvec` or `denpoly` instead", :denvec)
     lt = length(t)
     d = zeros(lt)
     d[(lt - length(t.den) + 1):end] = t.den[:]
     return d
 end
 
-denpoly(G::SisoRational) = Poly(den(G))
-numpoly(G::SisoRational) = Poly(num(G))
+numvec(t::SisoRational) = t.num[:]
+denvec(t::SisoRational) = t.den[:]
+numpoly(t::SisoRational) = copy(t.num)
+denpoly(t::SisoRational) = copy(t.den)
 
 function evalfr(sys::SisoRational, s::Number)
     S = promote_type(typeof(s), Float64)
-    den = polyval(sys.den, s)
+    den = sys.den(s)
     if den == zero(S)
         convert(S, Inf)
     else
-        polyval(sys.num, s)/den
+        sys.num(s)/den
     end
 end
 

--- a/src/types/sisozpk.jl
+++ b/src/types/sisozpk.jl
@@ -57,15 +57,17 @@ function minreal(sys::SisoZpk, eps::Real)
 end
 
 function Base.num(t::SisoZpk)
+    Base.depwarn("`num is deprecated for getting numerator, use `numvec` or `numpoly` instead", :numvec)
     return copy(t.z)
 end
 
 function Base.den(t::SisoZpk)
+    Base.depwarn("`den is deprecated for getting denominator, use `denvec` or `denpoly` instead", :denvec)
     return copy(t.p)
 end
 
-tzero(sys::SisoZpk) = num(sys)
-pole(sys::SisoZpk) = den(sys)
+tzero(sys::SisoZpk) = copy(sys.z)
+pole(sys::SisoZpk) = copy(sys.p)
 
 function zp2polys(vec)
     polys = Array{Poly{Float64},1}(0)
@@ -86,13 +88,11 @@ function zp2polys(vec)
     polys
 end
 
-function numpoly(G::SisoZpk)
-    zpolys = zp2polys(G.z)
-end
+numvec(t::SisoZpk) = numpoly(t)[:]
+denvec(t::SisoZpk) = denpoly(t)[:]
 
-function denpoly(G::SisoZpk)
-    ppolys = zp2polys(G.p)
-end
+numpoly(t::SisoZpk) = prod(zp2polys(t.z))*t.k
+denpoly(t::SisoZpk) = prod(zp2polys(t.p))
 
 function evalfr(sys::SisoZpk, s::Number)
     S = promote_type(typeof(s), Float64)

--- a/src/types/tf2ss.jl
+++ b/src/types/tf2ss.jl
@@ -43,13 +43,15 @@ siso_tf_to_ss(t::SisoTf) = siso_tf_to_ss(convert(SisoRational, t))
 
 function siso_tf_to_ss(t::SisoRational)
     t = normalize_tf(t)
-    tnum = num(t)
-    tden = den(t)
+    tnum0 = numvec(t)
+    tden = denvec(t)
     len = length(tden)
+    #Pad tnum0 with zeros
+    tnum = [zeros(len - length(tnum0)); tnum0]
     d = Array(Float64, 1, 1)
     d[1] = tnum[1]
 
-    if len==1 || tnum == zero(Poly{Float64})
+    if len==1 || tnum == [0.0]
         a = zeros(0, 0)
         b = zeros(0, 1)
         c = zeros(1, 0)
@@ -63,8 +65,10 @@ function siso_tf_to_ss(t::SisoRational)
 end
 
 function normalize_tf(t::SisoRational)
-    d = t.den[1]
-    return SisoTf(t.num/d, t.den/d)
+    num = numpoly(t)
+    den = denpoly(t)
+    d = denvec(t)[1]
+    return SisoTf(num/d, den/d)
 end
 
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -38,7 +38,7 @@ Returns `true` if the `TransferFunction` is proper. This means that order(den)
 \>= order(num))""" ->
 function isproper(t::TransferFunction)
     for s in t.matrix
-        if length(num(s)) > length(den(s))
+        if length(numpoly(s)) > length(denpoly(s))
             return false
         end
     end
@@ -99,9 +99,5 @@ end
 #Collect will create a copy and collect the elements
 unwrap(m::AbstractArray, args...) = unwrap!(collect(m), args...)
 unwrap(x::Number) = x
-
-
-numpoly(G::TransferFunction) = map(numpoly, G.matrix)
-denpoly(G::TransferFunction) = map(denpoly, G.matrix)
 
 poly2vec(p::Poly) = p.a[1:end]

--- a/test/test_generalizedtf.jl
+++ b/test/test_generalizedtf.jl
@@ -15,4 +15,20 @@ C_111 = tfg("(s+1)/(s+2)")
 @test zpk(C_011*C_111) == zpk([-1,-2],[-2],1)
 
 @test bode(C_111*C_011, logspace(-1,1)) == bode(tfg("(s+2)*((s+1)/(s+2))"), logspace(-1,1))
+
+# Test numpoly, numvec, denpoly, denvec for SisoZpk
+
+# Test deprecation (is not an error)
+#@test_err num(C_111.matrix[1,1])
+#@test_err den(C_111.matrix[1,1])
+
+@test_err numvec(C_111.matrix[1,1])
+@test_err denvec(C_111.matrix[1,1])
+
+@test_err numvec(C_111)
+@test_err denvec(C_111)
+
+@test_err numpoly(C_111)
+@test_err denpoly(C_111)
+
 end

--- a/test/test_transferfunction.jl
+++ b/test/test_transferfunction.jl
@@ -129,4 +129,28 @@ D_diffTs = tf([1], [2], 0.1)
 @test_err tf("z", 0)                # z creation can't be continuous
 @test_err tf("z")                   # z creation can't be continuous
 @test_err [z 0]                     # Sampling time mismatch (inferec could be implemented)
+
+# Test numpoly, numvec, denpoly, denvec for SisoRational
+
+# Test deprecation (is not an error)
+#@test_err num(C_111.matrix[1,1])
+#@test_err den(C_111.matrix[1,1])
+
+@test numvec(C_111.matrix[1,1]) == [1, 2]
+@test denvec(C_111.matrix[1,1]) == [1, 5]
+
+vecs = Array{Array{Float64,1},2}(1,2)
+vecs[1,1] = [1,2,3]; vecs[1,2] = [1, 2]
+@test numvec(D_221) == vecs
+vecs[1,1] = [1,-0.2,-0.15]; vecs[1,2] = [1, -0.2, -0.15]
+@test denvec(D_221) == vecs
+
+@test size(numpoly(D_221)) == (1,2)
+@test numpoly(D_221) == [ControlSystems.Poly([1, 2, 3.0]) ControlSystems.Poly([1, 2.0])]
+@test size(denpoly(D_221)) == (1,2)
+@test denpoly(D_221) == [ControlSystems.Poly([1, -0.2, -0.15]) ControlSystems.Poly([1, -0.2, -0.15])]
+
+#After switch to polynomials
+#@test numpoly(D_221) == [Polynomials.Poly([3.0, 2, 1]) Polynomials.Poly([2.0, 1])])
+#@test denpoly(D_221) == [Polynomials.Poly([-0.15, -0.2, 1]) Polynomials.Poly([-0.15, -0.2, 1])]
 end

--- a/test/test_zpk.jl
+++ b/test/test_zpk.jl
@@ -110,4 +110,35 @@ D_diffTs = zpk(tf([1], [2], 0.1))
 @test_err zpk("z")                   # z creation can't be continuous
 # Remove this when inferec is implemented
 @test_err [z 0]                     # Sampling time mismatch (inferec could be implemented)
+
+# Test numpoly, numvec, denpoly, denvec for SisoZpk
+
+# Test deprecation
+#@test_err num(C_111.matrix[1,1])
+#@test_err den(C_111.matrix[1,1])
+
+@test numvec(C_111.matrix[1,1]) == [1, 2]
+@test denvec(C_111.matrix[1,1]) == [1, 5]
+
+#Unwrap matrix to use approx_eq
+@test_approx_eq numvec(D_221)[1,1] [1, 2, 3]
+@test_approx_eq numvec(D_221)[1,2] [1, 2]
+
+@test_approx_eq denvec(D_221)[1,1] [1,-0.2,-0.15]
+@test_approx_eq denvec(D_221)[1,2] [1, -0.2, -0.15]
+
+@test size(numpoly(D_221)) == (1,2)
+@test numpoly(D_221)[1,1] ≈ ControlSystems.Poly([1,2,3.0])
+@test numpoly(D_221)[1,2] ≈ ControlSystems.Poly([1, 2.0])
+
+@test size(denpoly(D_221)) == (1,2)
+@test denpoly(D_221)[1,1] ≈ ControlSystems.Poly([1, -0.2, -0.15])
+@test denpoly(D_221)[1,2] ≈ ControlSystems.Poly([1, -0.2, -0.15])
+
+#After switch to polynomials
+#@test numpoly(D_221)[1,1] ≈ Polynomials.Poly([3.0, 2, 1])
+#@test numpoly(D_221)[1,2] ≈ Polynomials.Poly([2.0, 1])
+
+#@test denpoly(D_221) ≈ Polynomials.Poly([-0.15, -0.2, 1])
+#@test denpoly(D_221) ≈ Polynomials.Poly([-0.15, -0.2, 1])
 end


### PR DESCRIPTION
* Solving the problem #20 of Base.num and Base.den being badly defined for different siso types by deprecating and replacing them with numvec, numpoly, denvec, denpoly.

* Replaced all occurrences of `.num` and `.den` as well as `num(...)`, `den(...)` outside the files for the respective siso types.

* This enables us to start working on moving to `Polynomials` #22 as well as dcgain #15.

Feel free to look at the changes and comment on them. This should be one of the last steps before we can tag a new major version.
