### PR TITLE
Fixed bug #59

### DIFF
--- a/src/matrix_comps.jl
+++ b/src/matrix_comps.jl
@@ -150,7 +150,7 @@ function covar(sys::StateSpace, W::StridedMatrix)
         error("W must be a square matrix the same size as `sys.B` columns")
     end
     if !isstable(sys) || (iscontinuous(sys) && any(D .!= 0))
-        return Inf
+        return fill(Inf,(size(C,1),size(C,1)))
     end
     func = iscontinuous(sys) ? lyap : dlyap
     Q = func(A, B*W*B')

--- a/src/matrix_comps.jl
+++ b/src/matrix_comps.jl
@@ -140,22 +140,38 @@ function ctrb(A, B)
 end
 ctrb(sys::StateSpace) = ctrb(sys.A, sys.B)
 
-@doc """`covar(sys, W)`
+@doc """`P = covar(sys, W)`
 
-Calculate the stationary covariance of an lti-model `sys`, driven by gaussian
-white noise of covariance `W`""" ->
+Calculate the stationary covariance `P = E[y(t)y(t)']` of an lti-model `sys`, driven by gaussian
+white noise 'w' of covariance `E[w(t)w(τ)]=W*δ(t-τ)` where δ is the dirac delta.
+
+The ouput is if Inf if the system is unstable. Passing white noise directly to
+the output will result in infinite covariance in the corresponding outputs
+(P[D*W*D' .!= 0] = Inf) for contunuous systems.""" ->
 function covar(sys::StateSpace, W::StridedMatrix)
     (A, B, C, D) = (sys.A, sys.B, sys.C, sys.D)
     if size(B,2) != size(W, 1) || size(W, 1) != size(W, 2)
         error("W must be a square matrix the same size as `sys.B` columns")
     end
-    if !isstable(sys) || (iscontinuous(sys) && any(D .!= 0))
+    if !isstable(sys)
         return fill(Inf,(size(C,1),size(C,1)))
     end
     func = iscontinuous(sys) ? lyap : dlyap
-    Q = func(A, B*W*B')
-    return C*Q*C' + D*W*D'
+    try
+        Q = func(A, B*W*B')
+    catch
+        error("No solution to the Lyapunov equation was found")
+    end
+    P = C*Q*C'
+    if iscontinuous(sys)
+        P[D*W*D' .!= 0] = Inf
+    else
+        P += D*W*D'
+    end
+    return P
 end
+
+covar(sys::TransferFunction, W::StridedMatrix) = covar(ss(sys), W)
 
 # Note: the following function returns a Float64 when p=2, and a Tuple{Float64,Float64} when p=Inf.
 # This varargout behavior might not be a good idea.

--- a/src/matrix_comps.jl
+++ b/src/matrix_comps.jl
@@ -149,7 +149,7 @@ function covar(sys::StateSpace, W::StridedMatrix)
     if size(B,2) != size(W, 1) || size(W, 1) != size(W, 2)
         error("W must be a square matrix the same size as `sys.B` columns")
     end
-    if !isstable(sys) || any(D .!= 0)
+    if !isstable(sys) || (iscontinuous(sys) && any(D .!= 0))
         return Inf
     end
     func = iscontinuous(sys) ? lyap : dlyap

--- a/test/test_matrix_comps.jl
+++ b/test/test_matrix_comps.jl
@@ -22,4 +22,13 @@ Ab,Bb,Cb,T = ControlSystems.balance_statespace(A,B,C)
 
 @test_approx_eq ControlSystems.balance_transform(A,B,C) ControlSystems.balance_transform(sys)
 
+
+@test_approx_eq covar(sys, eye(2)) [0.002560975609756 0.002439024390244; 0.002439024390244 0.002560975609756]
+D2 = eye(2)
+sys2 = ss(A,B,C,D2, 1)
+@test_approx_eq covar(sys2, eye(2)) [1.000110108378310 -0.000010098377310; -0.000010098377310 1.000110108378310]
+#Direct term means infinite covariance
+sys3 = ss(A,B,C,D2)
+@test covar(sys3, eye(2)) == [Inf Inf; Inf Inf]
+
 end

--- a/test/test_matrix_comps.jl
+++ b/test/test_matrix_comps.jl
@@ -22,13 +22,20 @@ Ab,Bb,Cb,T = ControlSystems.balance_statespace(A,B,C)
 
 @test_approx_eq ControlSystems.balance_transform(A,B,C) ControlSystems.balance_transform(sys)
 
-
-@test_approx_eq covar(sys, eye(2)) [0.002560975609756 0.002439024390244; 0.002439024390244 0.002560975609756]
+W = eye(2)
+@test_approx_eq covar(sys, W) [0.002560975609756 0.002439024390244; 0.002439024390244 0.002560975609756]
 D2 = eye(2)
-sys2 = ss(A,B,C,D2, 1)
-@test_approx_eq covar(sys2, eye(2)) [1.000110108378310 -0.000010098377310; -0.000010098377310 1.000110108378310]
-#Direct term means infinite covariance
-sys3 = ss(A,B,C,D2)
-@test covar(sys3, eye(2)) == [Inf Inf; Inf Inf]
+@test_approx_eq covar(ss(A,B,C,D2, 1), W) [1.000110108378310 -0.000010098377310; -0.000010098377310 1.000110108378310]
+# Direct term means infinite covariance
+@test_approx_eq covar(ss(A,B,C,D2), W) [Inf Inf; Inf Inf]
+
+# No noise on second output should give finite variance
+@test_approx_eq covar(ss(A,B,C,[1 0; 0 0]), W) [Inf Inf; Inf 0.002560975609756]
+
+# Unstable system has inf covar
+@test covar(ss(eye(2),B,C,0), W) == [Inf Inf; Inf Inf]
+
+# Discrete system can have direct term
+@test_approx_eq covar(ss(A,B,C,D2,0.1),W) [1.00011010837831 -1.0098377309782909e-5; -1.0098377309782909e-5 1.00011010837831]
 
 end


### PR DESCRIPTION
This fixes bug #59.

This is a rebase of PR #60, where I decided to output a matrix of correct size when returning Inf.

It seems that Matlab does not have this behavior of returning Inf when there is a direct term for continuous systems, even though their documentation says so:
> For continuous-time systems with nonzero feedthrough, covar returns Inf for the output covariance P.

What is the correct behavior? @baggepinnen @aytekinar 

It also seems like I might have to fix the tolerance on the plot tests before pulling to make the tests pass.