### PR TITLE
Fix bugs in numvec/denvec

### DIFF
--- a/src/types/sisotf.jl
+++ b/src/types/sisotf.jl
@@ -69,7 +69,7 @@ function Base.den(t::SisoRational)
     return d
 end
 
-numvec(t::SisoRational) = t.num[:]
+numvec(t::SisoRational) = vcat(zeros(length(t)-length(t.num)), t.num[:])
 denvec(t::SisoRational) = t.den[:]
 numpoly(t::SisoRational) = copy(t.num)
 denpoly(t::SisoRational) = copy(t.den)

--- a/src/types/sisozpk.jl
+++ b/src/types/sisozpk.jl
@@ -88,7 +88,10 @@ function zp2polys(vec)
     polys
 end
 
-numvec(t::SisoZpk) = numpoly(t)[:]
+function numvec(t::SisoZpk)
+  np = numpoly(t)
+  vcat(zeros(length(t)-length(np)), np[:])
+end
 denvec(t::SisoZpk) = denpoly(t)[:]
 
 numpoly(t::SisoZpk) = prod(zp2polys(t.z))*t.k


### PR DESCRIPTION
Fixed a bug in `numvec`. Now `numvec` is supposed to return a vector
of length `length(t::System)`.