### PR TITLE
Removed Pkg.clone from julia code

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,8 @@ using CustomTest
 try
     Pkg.installed("ControlExamplePlots")
 catch
-    warn("ControlExamplePlots needs to be installed to test plots, adding now:")
-    Pkg.clone("https://github.com/JuliaControl/ControlExamplePlots.jl.git")
+    error("The unregistered package ControlExamplePlots is currently needed to test plots, install using:
+            Pkg.clone(\"https://github.com/JuliaControl/ControlExamplePlots.jl.git\")")
 end
 
 my_tests = ["test_statespace",


### PR DESCRIPTION
To comply with the rules of METADATA.jl we are not allowed to use Pkg.clone to install an unregistered package in the tests. This will have to be done manually by the user if tests are to be run. It is already run by travis. See https://github.com/JuliaLang/METADATA.jl/pull/5545 for discussion