### PR TITLE
WIP: First prototype for statespace systems with given numeric type.

### DIFF
--- a/src/freqresp.jl
+++ b/src/freqresp.jl
@@ -29,13 +29,13 @@ end
 # Implements algorithm found in:
 # Laub, A.J., "Efficient Multivariable Frequency Response Computations",
 # IEEE Transactions on Automatic Control, AC-26 (1981), pp. 407-408.
-function _preprocess_for_freqresp(sys::StateSpace)
+function _preprocess_for_freqresp{T}(sys::StateSpace{T})
     A, B, C, D = sys.A, sys.B, sys.C, sys.D
     F = hessfact(A)
-    H = F[:H]::Matrix{Float64}
-    T = full(F[:Q])
-    P = C*T
-    Q = T\B
+    H = F[:H]::Matrix{T} #TODO: Should be real? Same type as T? Obviously not if T::Integer...
+    Tmat = full(F[:Q]) # TODO name clash with the type parameter T, so renamed to Tmat
+    P = C*Tmat
+    Q = Tmat\B
     StateSpace(H, Q, P, D, sys.Ts, sys.statenames, sys.inputnames,
         sys.outputnames)
 end

--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -111,7 +111,7 @@ y, t, x, uout = lsim(sys,u,t,x0)
 plot(t,x, lab=["Position", "Velocity"]', xlabel="Time [s]")
 ```
 """ ->
-function lsim(sys::StateSpace, u::AbstractVecOrMat, t::AbstractVector,
+function lsim{T}(sys::StateSpace{T}, u::AbstractVecOrMat, t::AbstractVector,
         x0::VecOrMat=zeros(sys.nx, 1), method::Symbol=_issmooth(u) ? :foh : :zoh)
     ny, nu = size(sys)
     nx = sys.nx
@@ -136,7 +136,7 @@ function lsim(sys::StateSpace, u::AbstractVecOrMat, t::AbstractVector,
         dsys, x0map = c2d(sys, dt, :foh)
         x0 = x0map*[x0; u[1,:].']
     end
-    x = ltitr(dsys.A, dsys.B, map(Float64,u), map(Float64,x0))
+    x = ltitr(dsys.A, dsys.B, map(T,u), map(T,x0))
     y = (sys.C*(x.') + sys.D*(u.')).'
     return y, t, x
 end
@@ -255,8 +255,10 @@ _default_Ts(sys::TransferFunction{SisoGeneralized}) = 0.07
 #TODO a reasonable check
 _issmooth(u::Function) = false
 
+_issmooth(u) = false
+
 # Determine if a signal is "smooth"
-function _issmooth(u, thresh::AbstractFloat=0.75)
+function _issmooth(u::Array{Float64,1}, thresh::AbstractFloat=0.75) # TODO: Does it make sense for MIMO signals?, it doens't for complex signals
     u = [zeros(1, size(u, 2)); u]       # Start from 0 signal always
     dist = maximum(u) - minimum(u)
     du = abs(diff(u))

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -56,6 +56,11 @@ float64mat(A::Matrix) = map(Float64,A)
 float64mat(A::Matrix{Float64}) = A
 float64mat(A::Real) = float64mat([A])
 
+ensure_matrix(A::Vector) = reshape(A, size(A, 1), 1)
+ensure_matrix{T<:Number}(A::Matrix{T}) = A
+ensure_matrix{T<:Number}(A::T) = ensure_matrix([A])
+
+
 # Ensures the metadata for an LTISystem is valid
 function validate_names(kwargs, key, n)
     names = get(kwargs, key, "")

--- a/test/test_complex_sys.jl
+++ b/test/test_complex_sys.jl
@@ -1,0 +1,38 @@
+module TestComplexSys
+using CustomTest
+using Base.Test
+using ControlSystems
+
+# Just some test for early prototyping of statespace systems of
+# different numerical types
+
+# Simple first order system
+G1 = ss(-1-1im, 1, 1, 0)
+w = logspace(-1,1)
+G1_fr,_ = freqresp(G1, w)
+
+# Test freqeuncy reposne
+@test_approx_eq G1_fr 1 ./ (1im*w + 1 + 1im)
+
+# Step response
+t = 0:0.1:3
+y, _, _ = step(G1, t)
+@test_approx_eq y (1 - exp((-1-im)*t))/(1 + im)
+
+# Poles of the system
+@test pole(G1) == [-1-1im]
+
+
+@test ss(1,1,1,0.5im) + 0.5im == ss(1,1,1,1.0im)
+
+
+# Just try to add a transfer function with a complex
+# state-space model to see that nothing crashes
+s = tf("s")
+ss(1.0 + 1im,1,1,1.0) + 1/(s+1)
+
+
+# Add test for printing complex system
+
+
+end


### PR DESCRIPTION
Early attempt for support of statespace models with matrices of different numeric types after discussion with @mfalt, @baggepinnen. Different numeric types gives the user more flexibility, for example the following types of matrices could be useful,

Complex - There are some applications of this in power systems and electronics. Matlab doesn't handle this case very well.
BigFloat - When there are numerical issues or higher precision is required
Symbolic

This first prototype is limited to StateSpace models.

All tests pass except one for `tzero`, which is conversion related, and some for the printing of statespace models.

Does this seem reasonable?

Should the user be warned when he creates a complex system as in matlab?

Should there be a separate function `complexss` so that complex systems are not created by mistake?

It is a surprisingly well contained change, once we decide on how to handle the conversion in tzero, it could in principle be pulled, and further additions could be added separately.

TODO:
Does `tzero` work the same for complex systems?
Plotting functions for complex systems
Implement `conj` with correct behavior for complex systems
