### PR TITLE
remove nonstandard v prefix from Plots version requirement

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.5-
-Plots v0.7.4
+Plots 0.7.4
 Polynomials


### PR DESCRIPTION
this doesn't hurt anything, but it's more common without
