### PR TITLE
use 0.6.0-pre as minimum julia version

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6-
+julia 0.6.0-pre
 Plots 0.7.4
 Polynomials


### PR DESCRIPTION
since `abstract type` syntax wouldn't work on early 0.6.0-dev versions,
better to stick to the julia-0.5-compatible versions of the package there