### PR TITLE
add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ControlSystems.jl
 
+[![ControlSystems](http://pkg.julialang.org/badges/ControlSystems_0.5.svg)](http://pkg.julialang.org/?pkg=ControlSystems)
+[![ControlSystems](http://pkg.julialang.org/badges/ControlSystems_0.6.svg)](http://pkg.julialang.org/?pkg=ControlSystems)
 [![Build Status](https://travis-ci.org/JuliaControl/ControlSystems.jl.svg?branch=master)](https://travis-ci.org/JuliaControl/ControlSystems.jl)
 [![Coverage Status](https://coveralls.io/repos/github/JuliaControl/ControlSystems.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaControl/ControlSystems.jl?branch=master)
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![ControlSystems](http://pkg.julialang.org/badges/ControlSystems_0.6.svg)](http://pkg.julialang.org/?pkg=ControlSystems)
 [![Build Status](https://travis-ci.org/JuliaControl/ControlSystems.jl.svg?branch=master)](https://travis-ci.org/JuliaControl/ControlSystems.jl)
 [![Coverage Status](https://coveralls.io/repos/github/JuliaControl/ControlSystems.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaControl/ControlSystems.jl?branch=master)
+[![Latest](https://img.shields.io/badge/docs-latest-blue.svg)](http://juliacontrol.github.io/ControlSystems.jl/latest/)
 
 A control systems design toolbox for Julia.
 


### PR DESCRIPTION
This PR adds informative badges to the top of the README file to indicate for which versions of Julia the package is currently passing tests. See the results here
https://github.com/JuliaControl/ControlSystems.jl/tree/badges