### PR TITLE
Fixes for freqresp

### DIFF
--- a/src/freqresp.jl
+++ b/src/freqresp.jl
@@ -17,7 +17,7 @@ function freqresp{S<:Real}(sys::LTISystem, w::AbstractVector{S})
     end
     #Evil but nessesary type instability here
     sys = _preprocess_for_freqresp(sys)
-    resp = Array{Complex{eltype(w)}}(nw, ny, nu)
+    sys_fr = Array{Complex{eltype(w)}}(nw, ny, nu)
     for i=1:nw
         # TODO : This doesn't actually take advantage of Hessenberg structure
         # for statespace version.

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -463,7 +463,7 @@ nicholsplot
     Ni_La(ϕ)        = @. 0.090*10^(ϕ/60)
     getColor(mdb)   = convert(Colors.RGB,Colors.HSV(360*((mdb-minimum(Gains))/(maximum(Gains)-minimum(Gains)))^1.5,sat,val))
 
-    megaangles      = vcat(map(s -> 180/π*angle(vec(freqresp(s, w)[1])), systems)...)
+    megaangles      = vcat(map(s -> 180/π*angle(vec(freqresp(s, w))), systems)...)
     filter!(x-> !isnan(x), megaangles)
     extremeangles = extrema(megaangles)
     extremeangles

--- a/test/test_freqresp.jl
+++ b/test/test_freqresp.jl
@@ -18,6 +18,21 @@ G = ss([-5 0 0 0; 0 -1 -2.5 0; 0 4 0 0; 0 0 0 -6], [2 0; 0 1; 0 0; 0 2],
 @test evalfr(G, -1) ≈ [0.0 -0.3; 0.0 0.4]
 @test evalfr(G, 0) ≈ [0.0 0.0; 0.2 1/3]
 
+
+## Freqresp
+w = logspace(-1,1)
+
+H1 = tf(1)
+G1 = ss(1)
+@test freqresp(G1, w) == ones(Complex128, length(w), 1, 1)
+@test freqresp(H1, w) == ones(Complex128, length(w), 1, 1)
+
+H2 = tf(1, [1,1])
+G2 = ss(-1, 1, 1, 0)
+@test freqresp(G2, w) == reshape(1./(1 + im*w), length(w), 1, 1)
+@test freqresp(H2, w) == reshape(1./(1 + im*w), length(w), 1, 1)
+
+
 ## Shortcut notation for evalfr ##
 F = tf([1],[1,0.5],-1)
 omega = 2


### PR DESCRIPTION
1) Fixed freqresp for static statespace systems (A=[])

2) Removed 2nd… out arg from freqresp
The vector w is supplied as input so there is no need to send it back as output.