### PR TITLE
remove vect function

### DIFF
--- a/src/connections.jl
+++ b/src/connections.jl
@@ -48,12 +48,6 @@ end
 
 append(systems::LTISystem...) = append(promote(systems...)...)
 
-#This is needed until julia removes deprecated vect()
-function Base.vect(sys::Union{LTISystem, Real}...)
-    T = Base.promote_typeof(sys...)
-    copy!(Array{T}(length(sys)), sys)
-end
-
 function Base.vcat(systems::StateSpace...)
     # Perform checks
     nu = systems[1].nu


### PR DESCRIPTION
This function caused frequent error messages and is no longer needed.