### PR TITLE
Added precision argument to print and show functions

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ Plots 0.7.4
 Polynomials
 LaTeXStrings
 Requires
+Formatting

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -32,3 +32,4 @@ pages:
     - Synthesis: 'lib/synthesis.md'
     - 'Time and Frequency response': 'lib/timefreqresponse.md'
     - Plotting: 'lib/plotting.md'
+    - Display: 'lib/display.md'

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -20,12 +20,12 @@ Depth = 1
 ## Functions
 
 ```@contents
-Pages = ["lib/constructors.md", "lib/plotting.md"]
+Pages = ["lib/constructors.md", "lib/plotting.md", "lib/display.md"]
 ```
 
 ## Documentation Index
 
 ```@index
-Pages = ["lib/constructors.md", "lib/plotting.md", "lib/syntheis.md", "lib/timefreqresponse.md", "lib/analysis.md"]
+Pages = ["lib/constructors.md", "lib/plotting.md", "lib/syntheis.md", "lib/timefreqresponse.md", "lib/analysis.md", "lib/display.md"]
 Depth = 1
 ```

--- a/docs/src/lib/display.md
+++ b/docs/src/lib/display.md
@@ -1,0 +1,10 @@
+```@index
+Pages = ["display.md"]
+```
+
+# Displaying Transfer Functions
+
+```@docs
+print
+show
+```

--- a/src/ControlSystems.jl
+++ b/src/ControlSystems.jl
@@ -65,7 +65,10 @@ export  LTISystem,
         sigma,
         # utilities
         numpoly,
-        denpoly
+        denpoly,
+        # display
+        show,
+        print
 
 using Plots, LaTeXStrings, Requires, Formatting
 import Base: +, -, *, /, (./), (==), (.+), (.-), (.*), (!=), isapprox, convert, promote_op

--- a/src/ControlSystems.jl
+++ b/src/ControlSystems.jl
@@ -67,7 +67,7 @@ export  LTISystem,
         numpoly,
         denpoly
 
-using Plots, LaTeXStrings, Requires
+using Plots, LaTeXStrings, Requires, Formatting
 import Base: +, -, *, /, (./), (==), (.+), (.-), (.*), (!=), isapprox, convert, promote_op
 
 include("types/lti.jl")

--- a/src/types/polys.jl
+++ b/src/types/polys.jl
@@ -49,10 +49,11 @@ end
 
 Base.print(io::IO, p::Poly) = print_poly(io, p)
 
-function print_poly{T}(io::IO, p::Poly{T}, var=:x)
+function print_poly{T}(io::IO, p::Poly{T}, var=:x, precision::Int=-1)
+    pformat = precision >= 0 ? string(".", precision, "g") : "g"
     n = length(p)
     if n == 1
-        print(io, p[1])
+        print(io, format(p[1], conversion=pformat))
     else
         for j = 1:n
             pj = p[j]
@@ -63,11 +64,14 @@ function print_poly{T}(io::IO, p::Poly{T}, var=:x)
                 else
                     real(pj) < 0 ? print(io," - ") : print(io," + ")
                 end
+                exp = n-j
                 #Print pj if pj is the last coefficient, or pj is not identically 1
                 if j == n || abs(magpj - 1) > 2*eps(T)
-                    print(io, magpj)
+                    print(io, format(magpj, conversion=pformat))
+                    if exp > 0
+                        print(io, "*")
+                    end
                 end
-                exp = n-j
                 if exp > 0
                     print(io, var)
                     if exp > 1

--- a/src/types/sisotf.jl
+++ b/src/types/sisotf.jl
@@ -18,10 +18,10 @@ function minreal(sys::SisoRational, eps::Real=sqrt(eps()))
     return SisoRational(minreal(SisoZpk(sys), eps))
 end
 
-function print_siso(io::IO, t::SisoRational, var=:s)
+function print_siso(io::IO, t::SisoRational, var=:s, precision::Int=-1)
     # Convert the numerator and denominator to strings
-    numstr = sprint(print_poly, t.num, var)
-    denstr = sprint(print_poly, t.den, var)
+    numstr = sprint(print_poly, t.num, var, precision)
+    denstr = sprint(print_poly, t.den, var, precision)
 
     # Figure out the length of the separating line
     len_num = length(numstr)

--- a/src/types/sisozpk.jl
+++ b/src/types/sisozpk.jl
@@ -105,19 +105,19 @@ function evalfr(sys::SisoZpk, s::Number)
     end
 end
 
-function print_siso(io::IO, t::SisoZpk, var=:s)
+function print_siso(io::IO, t::SisoZpk, var=:s, precision::Int=-1)
     zpolys = zp2polys(t.z)
     ppolys = zp2polys(t.p)
     # Convert the numerator and denominator to strings
     if length(zpolys) < 2
-        numstr = ( length(zpolys) == 0 ) ? "1.0" : sprint(print_poly, zpolys[1], var)
+        numstr = ( length(zpolys) == 0 ) ? "1.0" : sprint(print_poly, zpolys[1], var, precision)
     else
-        numstr = reduce(*,"",["("*sprint(print_poly, z, var)*")" for z in zpolys])
+        numstr = reduce(*,"",["("*sprint(print_poly, z, var, precision)*")" for z in zpolys])
     end
     if length(ppolys) < 2
-        denstr = ( length(ppolys) == 0 ) ? "1.0" : sprint(print_poly, ppolys[1], var)
+        denstr = ( length(ppolys) == 0 ) ? "1.0" : sprint(print_poly, ppolys[1], var, precision)
     else
-        denstr = reduce(*,"",["("*sprint(print_poly, p, var)*")" for p in ppolys])
+        denstr = reduce(*,"",["("*sprint(print_poly, p, var, precision)*")" for p in ppolys])
     end
     # Figure out the length of the separating line
     len_num = length(numstr)
@@ -131,7 +131,8 @@ function print_siso(io::IO, t::SisoZpk, var=:s)
         denstr = "$(repeat(" ", div(dashcount - len_den, 2)))$denstr"
     end
 
-    gainstr = string(t.k)
+    pformat = precision >= 0 ? string(".", precision, "g") : "g"
+    gainstr = format(t.k, conversion=pformat)
     #Add spaces to account for gain string
     numstr = " "^(length(gainstr))*numstr
     denstr = " "^(length(gainstr))*denstr

--- a/src/types/transferfunction.jl
+++ b/src/types/transferfunction.jl
@@ -461,9 +461,35 @@ end
 ##                        Display Functions                        ##
 #####################################################################
 
+@doc """`print(io::IO, t::TransferFunction, precision::Int=-1)`
+
+Print a string representation of the transfer function:
+
+`io`: the `IO` stream to print to
+
+`t`: the transfer function
+
+`precision`: the precision to round each number to (default is 5)
+
+Other uses:
+
+`print(t::TransferFunction, precision::Int=-1)`: prints to `STDOUT`""" ->
 Base.print(io::IO, t::TransferFunction, precision::Int=-1) = show(io, t, precision)
 Base.print(t::TransferFunction, precision::Int=-1) = show(t, precision)
 
+@doc """`show(io::IO, t::TransferFunction, precision::Int=-1)`
+
+Print a string representation of the transfer function:
+
+`io`: the `IO` stream to print to
+
+`t`: the transfer function
+
+`precision`: the precision to round each number to (default is 5)
+
+Other uses:
+
+`show(t::TransferFunction, precision::Int=-1)`: prints to `STDOUT`""" ->
 function Base.show(io::IO, t::TransferFunction, precision::Int=-1)
     # Compose the name vectors
     inputs = format_names(t.inputnames, "Input ", "?")

--- a/src/types/transferfunction.jl
+++ b/src/types/transferfunction.jl
@@ -461,10 +461,10 @@ end
 ##                        Display Functions                        ##
 #####################################################################
 
-Base.print(io::IO, t::TransferFunction; precision::Int=-1) = show(io, t, precision=precision)
-Base.print(t::TransferFunction; precision::Int=-1) = show(t, precision=precision)
+Base.print(io::IO, t::TransferFunction, precision::Int=-1) = show(io, t, precision)
+Base.print(t::TransferFunction, precision::Int=-1) = show(t, precision)
 
-function Base.show(io::IO, t::TransferFunction; precision::Int=-1)
+function Base.show(io::IO, t::TransferFunction, precision::Int=-1)
     # Compose the name vectors
     inputs = format_names(t.inputnames, "Input ", "?")
     outputs = format_names(t.outputnames, "Output ", "?")
@@ -493,4 +493,4 @@ function Base.show(io::IO, t::TransferFunction; precision::Int=-1)
         print(io, "\nDiscrete-time transfer function model")
     end
 end
-Base.show(t::TransferFunction; precision::Int=-1) = show(STDOUT, t, precision=precision)
+Base.show(t::TransferFunction, precision::Int=-1) = show(STDOUT, t, precision)

--- a/src/types/transferfunction.jl
+++ b/src/types/transferfunction.jl
@@ -461,9 +461,10 @@ end
 ##                        Display Functions                        ##
 #####################################################################
 
-Base.print(io::IO, t::TransferFunction) = show(io, t)
+Base.print(io::IO, t::TransferFunction; precision::Int=-1) = show(io, t, precision=precision)
+Base.print(t::TransferFunction; precision::Int=-1) = show(t, precision=precision)
 
-function Base.show(io::IO, t::TransferFunction)
+function Base.show(io::IO, t::TransferFunction; precision::Int=-1)
     # Compose the name vectors
     inputs = format_names(t.inputnames, "Input ", "?")
     outputs = format_names(t.outputnames, "Output ", "?")
@@ -474,7 +475,7 @@ function Base.show(io::IO, t::TransferFunction)
             if !issiso(t)
                 println(io, inputs[i], " to ", outputs[o])
             end
-                print_siso(io, t.matrix[o, i], tftype)
+            print_siso(io, t.matrix[o, i], tftype, precision)
             if !(i == t.nu && o == t.ny)
                 print(io, "\n")
             end
@@ -492,3 +493,4 @@ function Base.show(io::IO, t::TransferFunction)
         print(io, "\nDiscrete-time transfer function model")
     end
 end
+Base.show(t::TransferFunction; precision::Int=-1) = show(STDOUT, t, precision=precision)

--- a/test/test_transferfunction.jl
+++ b/test/test_transferfunction.jl
@@ -76,19 +76,52 @@ tf(vecarray(1, 2, [0], [0]), vecarray(1, 2, [1], [1]), 0.005)
 @test size(C_222[1,[]]) == (1,0)
 
 # Printing
-res = ("TransferFunction:\nInput 1 to Output 1\ns^2 + 2.0s + 3.0\n-----------"*
-       "------\ns^2 + 8.0s + 15.0\n\nInput 1 to Output 2\ns^2 + 2.0s + 3.0\n-"*
-       "----------------\ns^2 + 8.0s + 15.0\n\nInput 2 to Output 1\n     s + "*
-       "2.0\n-----------------\ns^2 + 8.0s + 15.0\n\nInput 2 to Output 2\n   "*
-       "  s + 2.0\n-----------------\ns^2 + 8.0s + 15.0\n\nContinuous-time"*
-       " transfer function model")
+res = ("TransferFunction:\n"*
+       "Input 1 to Output 1\n"*
+       "s^2 + 2*s + 3\n"*
+       "--------------\n"*
+       "s^2 + 8*s + 15\n"*
+       "\n"*
+       "Input 1 to Output 2\n"*
+       "s^2 + 2*s + 3\n"*
+       "--------------\n"*
+       "s^2 + 8*s + 15\n"*
+       "\n"*
+       "Input 2 to Output 1\n"*
+       "    s + 2\n"*
+       "--------------\n"*
+       "s^2 + 8*s + 15\n"*
+       "\n"*
+       "Input 2 to Output 2\n"*
+       "    s + 2\n"*
+       "--------------\n"*
+       "s^2 + 8*s + 15\n"*
+       "\n"*
+       "Continuous-time transfer function model")
 @test sprint(show, C_222) == res
-res = ("TransferFunction:\nInput 1 to Output 1\nz^2 + 2.0z + 3.0\n-----------"*
-       "------\nz^2 - 0.2z - 0.15\n\nInput 1 to Output 2\nz^2 + 2.0z + 3.0\n-"*
-       "----------------\nz^2 - 0.2z - 0.15\n\nInput 2 to Output 1\n     z + "*
-       "2.0\n-----------------\nz^2 - 0.2z - 0.15\n\nInput 2 to Output 2\n   "*
-       "  z + 2.0\n-----------------\nz^2 - 0.2z - 0.15\n\nSample Time: 0.005 "*
-       "(seconds)\nDiscrete-time transfer function model")
+res = ("TransferFunction:\n"*
+       "Input 1 to Output 1\n"*
+       "  z^2 + 2*z + 3\n"*
+       "------------------\n"*
+       "z^2 - 0.2*z - 0.15\n"*
+       "\n"*
+       "Input 1 to Output 2\n"*
+       "  z^2 + 2*z + 3\n"*
+       "------------------\n"*
+       "z^2 - 0.2*z - 0.15\n"*
+       "\n"*
+       "Input 2 to Output 1\n"*
+       "      z + 2\n"*
+       "------------------\n"*
+       "z^2 - 0.2*z - 0.15\n"*
+       "\n"*
+       "Input 2 to Output 2\n"*
+       "      z + 2\n"*
+       "------------------\n"*
+       "z^2 - 0.2*z - 0.15\n"*
+       "\n"*
+       "Sample Time: 0.005 (seconds)\n"*
+       "Discrete-time transfer function model")
 @test sprint(show, D_222) == res
 
 # Type stability Continuous-time

--- a/test/test_transferfunction.jl
+++ b/test/test_transferfunction.jl
@@ -75,7 +75,7 @@ tf(vecarray(1, 2, [0], [0]), vecarray(1, 2, [1], [1]), 0.005)
 @test C_222[1,1:2] == C_221
 @test size(C_222[1,[]]) == (1,0)
 
-# Printing
+# Printing (default, specific precision, zpk)
 res = ("TransferFunction:\n"*
        "Input 1 to Output 1\n"*
        "s^2 + 2*s + 3\n"*
@@ -123,6 +123,67 @@ res = ("TransferFunction:\n"*
        "Sample Time: 0.005 (seconds)\n"*
        "Discrete-time transfer function model")
 @test sprint(show, D_222) == res
+res = ("TransferFunction:\n"*
+       "Input 1 to Output 1\n"*
+       "  s^2 + 2*s + 3\n"*
+       "-----------------\n"*
+       "s^2 + 8*s + 2e+01\n"*
+       "\n"*
+       "Input 1 to Output 2\n"*
+       "  s^2 + 2*s + 3\n"*
+       "-----------------\n"*
+       "s^2 + 8*s + 2e+01\n"*
+       "\n"*
+       "Input 2 to Output 1\n"*
+       "      s + 2\n"*
+       "-----------------\n"*
+       "s^2 + 8*s + 2e+01\n"*
+       "\n"*
+       "Input 2 to Output 2\n"*
+       "      s + 2\n"*
+       "-----------------\n"*
+       "s^2 + 8*s + 2e+01\n"*
+       "\n"*
+       "Continuous-time transfer function model")
+@test sprint(show, C_222, 1) == res
+res = ("TransferFunction:\n"*
+       "Input 1 to Output 1\n"*
+       "  z^2 + 2*z + 3\n"*
+       "-----------------\n"*
+       "z^2 - 0.2*z - 0.1\n"*
+       "\n"*
+       "Input 1 to Output 2\n"*
+       "  z^2 + 2*z + 3\n"*
+       "-----------------\n"*
+       "z^2 - 0.2*z - 0.1\n"*
+       "\n"*
+       "Input 2 to Output 1\n"*
+       "      z + 2\n"*
+       "-----------------\n"*
+       "z^2 - 0.2*z - 0.1\n"*
+       "\n"*
+       "Input 2 to Output 2\n"*
+       "      z + 2\n"*
+       "-----------------\n"*
+       "z^2 - 0.2*z - 0.1\n"*
+       "\n"*
+       "Sample Time: 0.005 (seconds)\n"*
+       "Discrete-time transfer function model")
+@test sprint(show, D_222, 1) == res
+res = ("TransferFunction:\n"*
+       "              s - 1.12345\n"*
+       "4.45678--------------------------\n"*
+       "       (s - 3.67891)(s - 2.54321)\n"*
+       "\n"*
+       "Continuous-time transfer function model")
+@test sprint(show, zpk([1.12345], [2.54321;3.67891], 4.45678)) == res
+res = ("TransferFunction:\n"*
+       "        s - 1.1\n"*
+       "4.5------------------\n"*
+       "   (s - 3.7)(s - 2.5)\n"*
+       "\n"*
+       "Continuous-time transfer function model")
+@test sprint(show, zpk([1.12345], [2.54321;3.67891], 4.45678), 2) == res
 
 # Type stability Continuous-time
 @test eltype(fill(tf("s"),2)) <: TransferFunction


### PR DESCRIPTION
I added a precision argument to `print` and `show` to allow for limiting the number of digits displayed by the two functions. Previously for coefficients that didn't come out to be nice numbers, the default number of digits made the output annoying interpret. 

Here's an example:
```
using ControlSystems
A = [-20 -2 0 0; 10 0 -10 0; 0 5 -100 -5; 0 0 4 0]
B = [2 0 0 0]'
C = [0 1 0 0]
D = 0
G = ss(A,B,C,D)
```
Outputting the transfer function to the terminal looked like this:
```
# Input
show(zpk(G))

# Output
TransferFunction:
                                 (s + 99.79959839197049)(s + 1.407374883553052e15)(s + 0.20040160804507176)
1.4210854715202004e-14------------------------------------------------------------------------------------------------
                      (s + 99.29631508731481)(s + 1.6701219833671543)(s + 18.905983873522935)(s + 0.12757905579519613)

Continuous-time transfer function model
```
I added some formatting to make the display a little cleaner:
```
# Input
show(zpk(G))

# Output
TransferFunction:
               (s + 99.7996)(s + 1.40737e+15)(s + 0.200402)
1.42109e-14----------------------------------------------------
           (s + 99.2963)(s + 1.67012)(s + 18.906)(s + 0.127579)

Continuous-time transfer function model
```
And adjustable:
```
# Input
show(zpk(G), 2)

# Output
TransferFunction:
         (s + 100)(s + 1.4e+15)(s + 0.2)
1.4e-14-----------------------------------
       (s + 99)(s + 1.7)(s + 19)(s + 0.13)

Continuous-time transfer function model
```