### PR TITLE
Fix: tzero for complex-valued StateSpace

### DIFF
--- a/src/types/conversion.jl
+++ b/src/types/conversion.jl
@@ -156,8 +156,8 @@ function balance_statespace(A::AbstractMatrix{P}, B::AbstractMatrix{P}, C::Abstr
 
     # Compute the transformation matrix
     mag_A = abs.(A)
-    mag_B = max.(abs.(B), zero(P))
-    mag_C = max.(abs.(C), zero(P))
+    mag_B = max.(abs.(B), zero(real(P)))
+    mag_C = max.(abs.(C), zero(real(P)))
     T = balance_transform(mag_A, mag_B, mag_C, perm)
 
     # Perform the transformation

--- a/test/test_complex.jl
+++ b/test/test_complex.jl
@@ -39,4 +39,4 @@ s = tf("s");
 @test tzero(ss((s-2.0-1.5im)^3/(s+1+im)/(s+2)^3)) ≈ fill(2.0 + 1.5im, 3) rtol=1e-4
 @test tzero(ss((s-2.0-1.5im)*(s-3.0)/(s+1+im)/(s+2)^2)) ≈ [3.0, 2.0 + 1.5im] rtol=1e-14
 
-end-
+end

--- a/test/test_complex.jl
+++ b/test/test_complex.jl
@@ -32,4 +32,11 @@ C_2 = zpk([-1+im], [], 1.0+1im)
 
 @test 1 / ( tf("s") + 1 + im ) == tf([1], [1, 1+im])
 
-end
+s = tf("s");
+@test tzero(ss(-1, 1, 1, 1.0im)) ≈ [-1.0 + im] rtol=1e-15
+@test tzero(ss([-1.0-im 1-im; 2 0], [2; 0], [-1+1im -0.5-1.25im], 1)) ≈ [-1-2im, 2-im]
+
+@test tzero(ss((s-2.0-1.5im)^3/(s+1+im)/(s+2)^3)) ≈ fill(2.0 + 1.5im, 3) rtol=1e-4
+@test tzero(ss((s-2.0-1.5im)*(s-3.0)/(s+1+im)/(s+2)^2)) ≈ [3.0, 2.0 + 1.5im] rtol=1e-14
+
+end-


### PR DESCRIPTION
Bug fix: `tzero` for complex-valued `StateSpace` returned the conjugate of single complex zeros.