### PR TITLE
Updated the call of lsim in test_timeresp.jl to use keyword arguments…

### DIFF
--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -88,6 +88,8 @@ To simulate a unit step, use `(x,i)-> 1`, for a ramp, use `(x,i)-> i*h`, for a s
 Usage example:
 ```julia
 using LinearAlgebra # For identity matrix I
+using Plots
+
 A = [0 1; 0 0]
 B = [0;1]
 C = [1 0]
@@ -99,8 +101,8 @@ L = lqr(sys,Q,R)
 u(x,t) = -L*x # Form control law,
 t=0:0.1:5
 x0 = [1,0]
-y, t, x, uout = lsim(sys,u,t,x0)
-plot(t,x, lab=["Position", "Velocity"]', xlabel="Time [s]")
+y, t, x, uout = lsim(sys,u,t;x0=x0)
+plot(t,x, lab=["Position", "Velocity"], xlabel="Time [s]")
 ```
 """
 function lsim(sys::StateSpace, u::AbstractVecOrMat, t::AbstractVector;

--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -102,7 +102,7 @@ u(x,t) = -L*x # Form control law,
 t=0:0.1:5
 x0 = [1,0]
 y, t, x, uout = lsim(sys,u,t;x0=x0)
-plot(t,x, lab=["Position", "Velocity"], xlabel="Time [s]")
+plot(t,x, lab=["Position" "Velocity"], xlabel="Time [s]")
 ```
 """
 function lsim(sys::StateSpace, u::AbstractVecOrMat, t::AbstractVector;

--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -101,7 +101,7 @@ L = lqr(sys,Q,R)
 u(x,t) = -L*x # Form control law,
 t=0:0.1:5
 x0 = [1,0]
-y, t, x, uout = lsim(sys,u,t;x0=x0)
+y, t, x, uout = lsim(sys,u,t,x0=x0)
 plot(t,x, lab=["Position" "Velocity"], xlabel="Time [s]")
 ```
 """

--- a/test/test_timeresp.jl
+++ b/test/test_timeresp.jl
@@ -13,7 +13,7 @@ L = lqr(sys,Q,R)
 u(x,i) = -L*x # Form control law
 t=0:0.1:50
 x0 = [1.,0]
-y, t, x, uout = lsim(sys,u,t;x0=x0) # Continuous time
+y, t, x, uout = lsim(sys,u,t,x0=x0) # Continuous time
 
 th = 1e-6
 @test sum(abs.(x[end,:])) < th

--- a/test/test_timeresp.jl
+++ b/test/test_timeresp.jl
@@ -13,7 +13,7 @@ L = lqr(sys,Q,R)
 u(x,i) = -L*x # Form control law
 t=0:0.1:50
 x0 = [1.,0]
-y, t, x, uout = lsim(sys,u,t,x0=x0) # Continuous time
+y, t, x, uout = lsim(sys,u,t;x0=x0) # Continuous time
 
 th = 1e-6
 @test sum(abs.(x[end,:])) < th


### PR DESCRIPTION
… for x0. The same modification done in timeresp.jl, wherein additionally the string for the label was corrected (transpose removed) and `using Plots` added.