### PR TITLE
Remove unnecessary type restrictions

### DIFF
--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -8,7 +8,7 @@ pole(sys::SisoTf) = error("pole is not implemented for type $(typeof(sys))")
 # converting to zpk before works better in the cases I have tested.
 pole(sys::TransferFunction) = pole(zpk(sys))
 
-function pole(sys::TransferFunction{SisoZpk{T,TR}}) where {T<:Number, TR<:Number}
+function pole(sys::TransferFunction{SisoZpk{T,TR}}) where {T, TR}
     # With right TR, this code works for any SisoTf
 
     # Calculate least common denominator of the minors,
@@ -70,7 +70,7 @@ end
 
 Compute the determinant of the Matrix `sys` of SisoTf systems, returns a SisoTf system."""
 # TODO: improve this implementation, should be more efficient ones
-function det(sys::Matrix{S}) where {T<:Number, TR, S<:SisoZpk}
+function det(sys::Matrix{S}) where {S<:SisoZpk}
     ny, nu = size(sys)
     @assert ny == nu "Matrix is not square"
     if ny == 1
@@ -197,7 +197,8 @@ function tzero(A::Matrix{<:Number}, B::Matrix{<:Number}, C::Matrix{<:Number}, D:
     A2, B2, C2, D2 = promote(A,B,C,D, fill(zero(T)/one(T),0,0)) # If Int, we get Float64
     tzero(A2, B2, C2, D2)
 end
-function tzero(A::Matrix{T}, B::Matrix{T}, C::Matrix{T}, D::Matrix{T}) where T<:BlasFloat
+function tzero(A::AbstractMatrix, B::AbstractMatrix, C::AbstractMatrix, D::AbstractMatrix)
+    T = promote_type(eltype(A), eltype(B), eltype(C), eltype(D))
     # Balance the system
     A, B, C = balance_statespace(A, B, C)
 
@@ -232,13 +233,14 @@ function tzero(A::Matrix{T}, B::Matrix{T}, C::Matrix{T}, D::Matrix{T}) where T<:
     return zs
 end
 
-reduce_sys(A::AbstractMatrix{<:BlasFloat}, B::AbstractMatrix{<:BlasFloat}, C::AbstractMatrix{<:BlasFloat}, D::AbstractMatrix{<:BlasFloat}, meps::BlasFloat) =
+reduce_sys(A::AbstractMatrix, B::AbstractMatrix, C::AbstractMatrix, D::AbstractMatrix, meps::AbstractFloat) =
     reduce_sys(promote(A,B,C,D)..., meps)
 """
 Implements REDUCE in the Emami-Naeini & Van Dooren paper. Returns transformed
 A, B, C, D matrices. These are empty if there are no zeros.
 """
-function reduce_sys(A::AbstractMatrix{T}, B::AbstractMatrix{T}, C::AbstractMatrix{T}, D::AbstractMatrix{T}, meps::BlasFloat) where T <: BlasFloat
+function reduce_sys(A::AbstractMatrix, B::AbstractMatrix, C::AbstractMatrix, D::AbstractMatrix, meps::AbstractFloat)
+    T = promote_type(eltype(A), eltype(B), eltype(C), eltype(D))
     Cbar, Dbar = C, D
     if isempty(A)
         return A, B, C, D
@@ -313,7 +315,7 @@ If `!allMargins`, return only the smallest margin
 If `full` return also `fullPhase`
 
 """
-function margin(sys::LTISystem, w::AbstractVector{S}; full=false, allMargins=false) where S<:Real
+function margin(sys::LTISystem, w::AbstractVector{<:Real}; full=false, allMargins=false)
     ny, nu = size(sys)
 
     if allMargins
@@ -346,7 +348,7 @@ end
 
 returns frequencies for gain margins, gain margins, frequencies for phase margins, phase margins
 """
-function sisomargin(sys::LTISystem, w::AbstractVector{S}; full=false, allMargins=false) where S<:Real
+function sisomargin(sys::LTISystem, w::AbstractVector{<:Real}; full=false, allMargins=false)
     ny, nu = size(sys)
     if ny !=1 || nu != 1
         error("System must be SISO, use `margin` instead")

--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -192,13 +192,12 @@ end
 # Note that this returns either Vector{ComplexF32} or Vector{Float64}
 tzero(sys::StateSpace) = tzero(sys.A, sys.B, sys.C, sys.D)
 # Make sure everything is BlasFloat
-function tzero(A::Matrix{<:Number}, B::Matrix{<:Number}, C::Matrix{<:Number}, D::Matrix{<:Number})
-    T = promote_type(eltype(A), eltype(B), eltype(C), eltype(D))
-    A2, B2, C2, D2 = promote(A,B,C,D, fill(zero(T)/one(T),0,0)) # If Int, we get Float64
-    tzero(A2, B2, C2, D2)
-end
 function tzero(A::AbstractMatrix, B::AbstractMatrix, C::AbstractMatrix, D::AbstractMatrix)
     T = promote_type(eltype(A), eltype(B), eltype(C), eltype(D))
+    A2, B2, C2, D2, _ = promote(A,B,C,D, fill(zero(T)/one(T),0,0)) # If Int, we get Float64
+    tzero(A2, B2, C2, D2)
+end
+function tzero(A::AbstractMatrix{T}, B::AbstractMatrix{T}, C::AbstractMatrix{T}, D::AbstractMatrix{T}) where {T <: Union{AbstractFloat,Complex{<:AbstractFloat}}#= For eps(T) =#}
     # Balance the system
     A, B, C = balance_statespace(A, B, C)
 
@@ -233,8 +232,7 @@ function tzero(A::AbstractMatrix, B::AbstractMatrix, C::AbstractMatrix, D::Abstr
     return zs
 end
 
-reduce_sys(A::AbstractMatrix, B::AbstractMatrix, C::AbstractMatrix, D::AbstractMatrix, meps::AbstractFloat) =
-    reduce_sys(promote(A,B,C,D)..., meps)
+
 """
 Implements REDUCE in the Emami-Naeini & Van Dooren paper. Returns transformed
 A, B, C, D matrices. These are empty if there are no zeros.

--- a/src/connections.jl
+++ b/src/connections.jl
@@ -162,9 +162,9 @@ Base.typed_hcat(::Type{T}, X::Number...) where {T<:LTISystem, N} = hcat(convert.
 # end
 
 
-blockdiag(mats::Matrix...) = blockdiag(promote(mats...)...)
+blockdiag(mats::AbstractMatrix...) = blockdiag(promote(mats...)...)
 
-function blockdiag(mats::Matrix{T}...) where T
+function blockdiag(mats::AbstractMatrix{T}...) where T
     rows = Int[size(m, 1) for m in mats]
     cols = Int[size(m, 2) for m in mats]
     res = zeros(T, sum(rows), sum(cols))

--- a/src/freqresp.jl
+++ b/src/freqresp.jl
@@ -5,7 +5,7 @@ Evaluate the frequency response of a linear system
 `w -> C*((iw*im -A)^-1)*B + D`
 
 of system `sys` over the frequency vector `w`."""
-function freqresp(sys::LTISystem, w_vec::AbstractVector{S}) where {S<:Real}
+function freqresp(sys::LTISystem, w_vec::AbstractVector{<:Real})
     # Create imaginary freq vector s
     if !iscontinuous(sys)
         Ts = sys.Ts == -1 ? 1.0 : sys.Ts
@@ -62,7 +62,7 @@ function evalfr(sys::StateSpace{T0}, s::Number) where {T0}
     end
 end
 
-function evalfr(G::TransferFunction{<:SisoTf{T0}}, s::Number) where {T0}
+function evalfr(G::TransferFunction{<:SisoTf}, s::Number)
     map(m -> evalfr(m,s), G.matrix)
 end
 
@@ -133,7 +133,7 @@ function sigma(sys::LTISystem, w::AbstractVector)
 end
 sigma(sys::LTISystem) = sigma(sys, _default_freq_vector(sys, Val{:sigma}()))
 
-function _default_freq_vector(systems::Vector{T}, plot) where T<:LTISystem
+function _default_freq_vector(systems::Vector{<:LTISystem}, plot)
     min_pt_per_dec = 60
     min_pt_total = 200
     bounds = map(sys -> _bounds_and_features(sys, plot)[1], systems)

--- a/src/matrix_comps.jl
+++ b/src/matrix_comps.jl
@@ -72,7 +72,7 @@ end
 Compute the solution `X` to the discrete Lyapunov equation
 `AXA' - X + Q = 0`.
 """
-function dlyap(A::AbstractMatrix{T}, Q) where T
+function dlyap(A::AbstractMatrix, Q)
     lhs = kron(A, conj(A))
     lhs = I - lhs
     x = lhs\reshape(Q, prod(size(Q)), 1)
@@ -107,7 +107,7 @@ Compute the observability matrix for the system described by `(A, C)` or `sys`.
 Note that checking for observability by computing the rank from `obsv` is
 not the most numerically accurate way, a better method is checking if
 `gram(sys, :o)` is positive definite."""
-function obsv(A::AbstractMatrix{T}, C::AbstractMatrix{T}) where {T <: Number}
+function obsv(A::AbstractMatrix{T}, C::AbstractMatrix) where T
     n = size(A, 1)
     ny = size(C, 1)
     if n != size(C, 2)
@@ -422,7 +422,7 @@ function balance(A, perm::Bool=true)
     return S, P, B
 end
 
-function cswap!(i::Integer, j::Integer, X::StridedMatrix{T}) where T<:Number
+function cswap!(i::Integer, j::Integer, X::StridedMatrix)
     for k = 1:size(X,1)
         X[i, k], X[j, k] = X[j, k], X[i, k]
     end

--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -187,10 +187,10 @@ If `x0` is not provided, a zero-vector is used.
 
 If `u` is a function, then `u(x,i)` is called to calculate the control signal every iteration. This can be used to provide a control law such as state feedback `u=-Lx` calculated by `lqr`. In this case, an integrer `iters` must be provided that indicates the number of iterations.
 """
-function ltitr(A::Matrix{T}, B::Matrix{T}, u::AbstractVecOrMat{T},
+function ltitr(A::AbstractMatrix{T}, B::AbstractMatrix{T}, u::AbstractVecOrMat,
         x0::VecOrMat=zeros(T, size(A, 1))) where T
     n = size(u, 1)
-    x = Array{T}(undef, size(A, 1), n)
+    x = similar(A, size(A, 1), n)
     for i=1:n
         x[:,i] = x0
         x0 = A * x0 + B * u[i,:]
@@ -199,11 +199,11 @@ function ltitr(A::Matrix{T}, B::Matrix{T}, u::AbstractVecOrMat{T},
 end
 
 
-function ltitr(A::Matrix{T}, B::Matrix{T}, u::Function, t,
+function ltitr(A::AbstractMatrix{T}, B::AbstractMatrix{T}, u::Function, t,
     x0::VecOrMat=zeros(T, size(A, 1))) where T
     iters = length(t)
-    x = Array{T}(undef, size(A, 1), iters)
-    uout = Array{T}(undef, size(B, 2), iters)
+    x = similar(A, size(A, 1), iters)
+    uout = similar(A, size(B, 2), iters)
 
     for i=1:iters
         x[:,i] = x0

--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -188,7 +188,7 @@ If `x0` is not provided, a zero-vector is used.
 If `u` is a function, then `u(x,i)` is called to calculate the control signal every iteration. This can be used to provide a control law such as state feedback `u=-Lx` calculated by `lqr`. In this case, an integrer `iters` must be provided that indicates the number of iterations.
 """
 function ltitr(A::Matrix{T}, B::Matrix{T}, u::AbstractVecOrMat{T},
-        x0::VecOrMat{T}=zeros(T, size(A, 1))) where T
+        x0::VecOrMat=zeros(T, size(A, 1))) where T
     n = size(u, 1)
     x = Array{T}(undef, size(A, 1), n)
     for i=1:n
@@ -200,7 +200,7 @@ end
 
 
 function ltitr(A::Matrix{T}, B::Matrix{T}, u::Function, t,
-    x0::VecOrMat{T}=zeros(T, size(A, 1))) where T
+    x0::VecOrMat=zeros(T, size(A, 1))) where T
     iters = length(t)
     x = Array{T}(undef, size(A, 1), iters)
     uout = Array{T}(undef, size(B, 2), iters)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -27,7 +27,9 @@ to_matrix(T, A::Adjoint{R, MT}) where {R<:Number, MT<:AbstractMatrix} = to_matri
 function roots2real_poly_factors(roots::Vector{cT}) where cT <: Number
     T = real(cT)
     poly_factors = Vector{Poly{T}}()
-
+    @static if VERSION > v"1.2.0-DEV.0" # Sort one more time to handle GenericLinearAlgebra not being updated
+        sort!(roots, by=LinearAlgebra.eigsortby)
+    end
     for k=1:length(roots)
         r = roots[k]
 


### PR DESCRIPTION
This loosening of restrictions is often needed for handling weird float types (MonteCarloMeasurements.jl/dual numbers etc.). Also removes some boilerplate where generic type parameters were declared but never used.