### PR TITLE
Remove defenition of dlqr for vector case

### DIFF
--- a/src/synthesis.jl
+++ b/src/synthesis.jl
@@ -100,10 +100,6 @@ function dlqr(A, B, Q, R)
     return K
 end
 
-function dlqr(A, B::Vector, Q, R)
-    dlqr(A, reshape(B, length(B), 1), Q, R)
-end
-
 """`dkalman(A, C, R1, R2)` kalman(sys, R1, R2)`
 
 Calculate the optimal Kalman gain for discrete time systems


### PR DESCRIPTION
It seems completely unnessesary, i.e the original definition seems to work for vectors already?