### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,10 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+If this is issue is reporting a bug, please verify that the bug occurs for the latest released version of ControlSystems, see the [version page](https://github.com/JuliaControl/ControlSystems.jl/releases). You can verify your installed version in the REPL using `pkg> st ControlSystems`.


### PR DESCRIPTION
This adds an issue template prompting users to verify their installed version of ControlSystems before reporting a bug.