### PR TITLE
Sampletimes: Counter-suggestion to suggestion PR 294 to PR 256 

### DIFF
--- a/src/ControlSystems.jl
+++ b/src/ControlSystems.jl
@@ -110,8 +110,9 @@ abstract type AbstractSystem end
 
 include("types/TimeType.jl")
 ## Added interface:
-#   sampletime(Lti) -> Number
 #   time(Lti) -> TimeType (not exported)
+#   sampletime(Lti) = sampletime(time(Lti)) -> Number (exported)
+
 
 include("types/Lti.jl")
 

--- a/src/ControlSystems.jl
+++ b/src/ControlSystems.jl
@@ -87,6 +87,7 @@ export  LTISystem,
         denvec,
         numpoly,
         denpoly,
+        sampletime,
         iscontinuous,
         isdiscrete
 
@@ -109,7 +110,8 @@ abstract type AbstractSystem end
 
 include("types/TimeType.jl")
 ## Added interface:
-#   time(Lti) -> Number
+#   sampletime(Lti) -> Number
+#   time(Lti) -> TimeType (not exported)
 
 include("types/Lti.jl")
 

--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -118,7 +118,7 @@ Compute the zeros, poles, and gains of system `sys`.
 
 `k` : Matrix{Float64}, (ny x nu)"""
 function zpkdata(sys::LTISystem)
-    G = convert(TransferFunction{timetype(sys),SisoZpk}, sys)
+    G = convert(TransferFunction{typeof(time(sys)),SisoZpk}, sys)
 
     zs = map(x -> x.z, G.matrix)
     ps = map(x -> x.p, G.matrix)
@@ -134,7 +134,7 @@ poles, `ps`, of `sys`"""
 function damp(sys::LTISystem)
     ps = pole(sys)
     if isdiscrete(sys)
-        ps = log(ps)/sys.Ts
+        ps = log(ps)/sampletime(sys)
     end
     Wn = abs.(ps)
     order = sortperm(Wn; by=z->(abs(z), real(z), imag(z)))
@@ -446,7 +446,7 @@ function delaymargin(G::LTISystem)
     ωϕₘ   = m[3][i]
     dₘ    = ϕₘ/ωϕₘ
     if isdiscrete(G)
-        dₘ /= G.Ts # Give delay margin in number of sample times, as matlab does
+        dₘ /= sampletime(G) # Give delay margin in number of sample times, as matlab does
     end
     dₘ
 end

--- a/src/discrete.jl
+++ b/src/discrete.jl
@@ -222,7 +222,7 @@ function lsima(sys::StateSpace, t::AbstractVector, r::AbstractVector, control_si
         if iscontinuous(sys)
             dsys = c2d(sys, dt, :zoh)[1]
         else
-            if sys.Ts != dt
+            if sampletime(sys) != dt
                 error("Time vector must match sample time for discrete system")
             end
             dsys = sys

--- a/src/freqresp.jl
+++ b/src/freqresp.jl
@@ -10,7 +10,7 @@ function freqresp(sys::LTISystem, w_vec::AbstractVector{<:Real})
     if iscontinuous(sys)
         s_vec = im*w_vec
     else
-        s_vec = exp.(w_vec*(im*sys.Ts))
+        s_vec = exp.(w_vec*(im*sampletime(sys)))
     end
     if isa(sys, StateSpace)
         sys = _preprocess_for_freqresp(sys)
@@ -74,7 +74,8 @@ end
 function (sys::TransferFunction)(z_or_omega::Number, map_to_unit_circle::Bool)
     @assert isdiscrete(sys) "It only makes no sense to call this function with discrete systems"
     if map_to_unit_circle
-        isreal(z_or_omega) ? evalfr(sys,exp(im*z_or_omega.*sys.Ts)) : error("To map to the unit circle, omega should be real")
+        dt = sampletime(sys)
+        isreal(z_or_omega) ? evalfr(sys,exp(im*z_or_omega.*dt)) : error("To map to the unit circle, omega should be real")
     else
         evalfr(sys,z_or_omega)
     end
@@ -169,7 +170,7 @@ function _bounds_and_features(sys::LTISystem, plot::Val)
         w2 = 2.0
     end
     if isdiscrete(sys) # Do not draw above Nyquist freq for disc. systems
-        w2 = min(w2, log10(π/sys.Ts))
+        w2 = min(w2, log10(π/sampletime(sys)))
     end
     return [w1, w2], zp
 end

--- a/src/matrix_comps.jl
+++ b/src/matrix_comps.jl
@@ -369,8 +369,9 @@ function _infnorm_two_steps_dt(sys::AbstractStateSpace, normtype::Symbol, tol=1e
 
     on_unit_circle = z -> abs(abs(z) - 1) < approxcirc # Helper fcn for readability
 
-    T = promote_type(real(numeric_type(sys)), Float64, typeof(true/sys.Ts))
-    Tw = typeof(one(T)/sys.Ts)
+    dt = sampletime(sys)
+    T = promote_type(real(numeric_type(sys)), Float64, typeof(true/dt))
+    Tw = typeof(one(T)/dt)
 
     if sys.nx == 0  # static gain
         return (T(opnorm(sys.D)), Tw(0))
@@ -381,7 +382,7 @@ function _infnorm_two_steps_dt(sys::AbstractStateSpace, normtype::Symbol, tol=1e
     # Check if there is a pole on the unit circle
     pidx = findfirst(on_unit_circle, pole_vec)
     if !(pidx isa Nothing)
-        return T(Inf), Tw(angle(pole_vec[pidx])/sys.Ts)
+        return T(Inf), Tw(angle(pole_vec[pidx])/dt)
     end
 
     if normtype == :hinf && any(z -> abs(z) > 1, pole_vec)
@@ -434,7 +435,7 @@ function _infnorm_two_steps_dt(sys::AbstractStateSpace, normtype::Symbol, tol=1e
         sort!(θ_vec)
 
         if isempty(θ_vec)
-            return T((1+tol)*lb), Tw(θ_peak/sys.Ts)
+            return T((1+tol)*lb), Tw(θ_peak/dt)
         end
 
         # Improve the lower bound

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -471,7 +471,7 @@ nicholsplot
     ny, nu = size(systems[1])
 
     if isdiscrete(systems[1])
-        w_nyquist = 2π/systems[1].Ts
+        w_nyquist = 2π/sampletime(systems[1])
         w = w[w.<= w_nyquist]
     end
     nw = length(w)

--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -50,7 +50,7 @@ function impulse(sys::StateSpace, t::AbstractVector; method=:cont)
         imp_sys = ss(sys.A, zeros(T, nx, 1), sys.C, zeros(T, ny, 1))
         x0s = sys.B
     else
-        u = (x,i) -> i == t[1] ? [one(T)]/sys.Ts : [zero(T)]
+        u = (x,i) -> i == t[1] ? [one(T)]/sampletime(sys) : [zero(T)]
         imp_sys = sys
         x0s = zeros(T, nx, nu)
     end
@@ -122,7 +122,7 @@ function lsim(sys::StateSpace, u::AbstractVecOrMat, t::AbstractVector;
         if !isdiscrete(sys)
             dsys = c2d(sys, dt, :zoh)[1]
         else
-            if sys.Ts != dt
+            if sampletime(sys) != dt
                 error("Time vector must match sample time for discrete system")
             end
             dsys = sys
@@ -155,7 +155,7 @@ function lsim(sys::StateSpace, u::Function, t::AbstractVector;
         if !isdiscrete(sys)
             dsys = c2d(sys, dt, :zoh)[1]
         else
-            if sys.Ts != dt
+            if sampletime(sys) != dt
                 error("Time vector must match sample time for discrete system")
             end
             dsys = sys
@@ -227,18 +227,17 @@ end
 
 function _default_dt(sys::LTISystem)
     if isdiscrete(sys)
-        dt = sys.Ts
+        return sampletime(sys)
     elseif !isstable(sys)
-        dt = 0.05
+        return 0.05
     else
         ps = pole(sys)
         r = minimum([abs.(real.(ps));0])
         if r == 0.0
             r = 1.0
         end
-        dt = 0.07/r
+        return 0.07/r
     end
-    return dt
 end
 
 

--- a/src/types/DelayLtiSystem.jl
+++ b/src/types/DelayLtiSystem.jl
@@ -16,7 +16,9 @@ struct DelayLtiSystem{T,S<:Real} <: LTISystem
     # end
 end
 
-time(sys::DelayLtiSystem) = time(sys.P)
+sampletime(sys::DelayLtiSystem) = sampletime(sys.P)
+iscontinuous(sys::DelayLtiSystem) = iscontinuous(sys.P)
+isdiscrete(sys::DelayLtiSystem) = isdiscrete(sys.P)
 
 # QUESTION: would psys be a good standard variable name for a PartionedStateSpace
 #           and perhaps dsys for a delayed system, (ambigous with discrete system though)

--- a/src/types/DelayLtiSystem.jl
+++ b/src/types/DelayLtiSystem.jl
@@ -16,9 +16,7 @@ struct DelayLtiSystem{T,S<:Real} <: LTISystem
     # end
 end
 
-sampletime(sys::DelayLtiSystem) = sampletime(sys.P)
-iscontinuous(sys::DelayLtiSystem) = iscontinuous(sys.P)
-isdiscrete(sys::DelayLtiSystem) = isdiscrete(sys.P)
+time(sys::DelayLtiSystem) = time(sys.P)
 
 # QUESTION: would psys be a good standard variable name for a PartionedStateSpace
 #           and perhaps dsys for a delayed system, (ambigous with discrete system though)

--- a/src/types/Lti.jl
+++ b/src/types/Lti.jl
@@ -72,7 +72,7 @@ end
 
 """`sampletime(sys)`
 Get the sampletime of system, same as `sys.Ts` but throws error on `Continous` systems."""
-sampletime(sys::LTISystem) = sampletime(sys.time)
+sampletime(sys::LTISystem) = sampletime(time(sys))
 
 common_time(systems::LTISystem...) = common_time(time(sys) for sys in systems)
 

--- a/src/types/Lti.jl
+++ b/src/types/Lti.jl
@@ -41,6 +41,9 @@ function issiso(sys::LTISystem)
     return ninputs(sys) == 1 && noutputs(sys) == 1
 end
 
+"""`time(sys::LTISystem)`
+Get the time::TimeType from system `sys`, usually sys.time """
+time(sys::LTISystem) = sys.time
 
 """`iscontinuous(sys)`
 
@@ -56,7 +59,7 @@ function Base.getproperty(sys::LTISystem, s::Symbol)
     if s === :Ts
         # if !isdiscrete(sys) # NOTE this line seems to be breaking inference of isdiscrete (is there a test for this?)
         if isdiscrete(sys)
-            return time(sys).Ts
+            return sampletime(sys)
         else
             @warn "Getting time 0.0 for non-discrete systems is deprecated. Check `isdiscrete` before trying to access time."
             return 0.0
@@ -66,20 +69,10 @@ function Base.getproperty(sys::LTISystem, s::Symbol)
     end
 end
 
-function Base.propertynames(sys::LTISystem, private::Bool=false)
-    names = if private
-        fieldnames(typeof(sys))
-    else
-        filter(!=(:time), fieldnames(typeof(sys)))
-    end
 
-    (names..., (isdiscrete(sys) ? (:Ts,) : ())...)
-end
-
-
-"""`timetype(sys)`
-Get the timetype of system. Usually typeof(sys.time)."""
-timetype(sys) = typeof(sys.time)
+"""`sampletime(sys)`
+Get the sampletime of system, same as `sys.Ts` but throws error on `Continous` systems."""
+sampletime(sys::LTISystem) = sampletime(sys.time)
 
 common_time(systems::LTISystem...) = common_time(time(sys) for sys in systems)
 

--- a/src/types/PartionedStateSpace.jl
+++ b/src/types/PartionedStateSpace.jl
@@ -26,7 +26,7 @@ function getproperty(sys::PartionedStateSpace, d::Symbol)
     ny1 = getfield(sys, :ny1)
 
     if d === :Ts
-        return P.Ts # Will throw deprecation until removed # DEPRECATED
+        return sampletime(P) # Will throw deprecation until removed # DEPRECATED
     elseif d === :time
         return P.time
     elseif d === :P

--- a/src/types/PartionedStateSpace.jl
+++ b/src/types/PartionedStateSpace.jl
@@ -27,8 +27,6 @@ function getproperty(sys::PartionedStateSpace, d::Symbol)
 
     if d === :Ts
         return sampletime(P) # Will throw deprecation until removed # DEPRECATED
-    elseif d === :time
-        return P.time
     elseif d === :P
         return P
     elseif d === :nu1

--- a/src/types/StateSpace.jl
+++ b/src/types/StateSpace.jl
@@ -24,8 +24,6 @@ end
 
 abstract type AbstractStateSpace{TimeT<:TimeType} <: LTISystem end
 
-time(sys::AbstractStateSpace) = sys.time
-
 struct StateSpace{TimeT, T, MT<:AbstractMatrix{T}} <: AbstractStateSpace{TimeT}
     A::MT
     B::MT
@@ -363,7 +361,7 @@ function Base.show(io::IO, sys::AbstractStateSpace)
     println(io, "D = \n", _string_mat_with_headers(sys.D), "\n")
     # Print sample time
     if isdiscrete(sys)
-        println(io, "Sample Time: ", sys.Ts, " (seconds)")
+        println(io, "Sample Time: ", sampletime(sys), " (seconds)")
     end
     # Print model type
     if iscontinuous(sys)

--- a/src/types/TimeType.jl
+++ b/src/types/TimeType.jl
@@ -1,12 +1,12 @@
 
 abstract type TimeType end
 
-const UNDEF_SAMPLEPERIOD = -1 # For handling promotion of Matrix to LTISystem
+const UNDEF_SAMPLETIME = -1 # For handling promotion of Matrix to LTISystem
 
 struct Discrete{T} <: TimeType
     Ts::T
     function Discrete{T}(Ts::T) where T
-        if Ts <= 0 && Ts != UNDEF_SAMPLEPERIOD
+        if Ts <= 0 && Ts != UNDEF_SAMPLETIME
             throw(ErrorException("Creating a continuous time system by setting sample time to 0 is no longer supported."))
         end
         new{T}(Ts)
@@ -21,10 +21,11 @@ Continuous(x::Continuous) = x
 # Simple converseion
 Discrete{T}(x::Discrete) where T = Discrete{T}(x.Ts)
 
+undef_sampletime(::Type{Discrete{T}}) where T = Discrete{T}(UNDEF_SAMPLETIME)
+undef_sampletime(::Type{Continuous}) where T = Continuous()
 
-undef_sampleperiod(::Type{Discrete{T}}) where T = Discrete{T}(UNDEF_SAMPLEPERIOD)
-undef_sampleperiod(::Type{Continuous}) where T = Continuous()
-
+sampletime(x::Discrete) = x.Ts
+sampletime(x::Continuous) = error("Continuous system has no sample time")
 
 # Promotion
 # Fallback to give useful error
@@ -40,11 +41,11 @@ common_time(x::TimeType, y::TimeType, z...) = common_time(common_time(x, y), z..
 common_time(a::Base.Generator) = reduce(common_time, a)
 
 function common_time(x::Discrete{T1}, y::Discrete{T2}) where {T1,T2}
-    if x != y && x.Ts != UNDEF_SAMPLEPERIOD && y.Ts != UNDEF_SAMPLEPERIOD
+    if x != y && x.Ts != UNDEF_SAMPLETIME && y.Ts != UNDEF_SAMPLETIME
          throw(ErrorException("Sampling time mismatch"))
     end
 
-    if x.Ts == UNDEF_SAMPLEPERIOD
+    if x.Ts == UNDEF_SAMPLETIME
         return Discrete{promote_type(T1,T2)}(y)
     else
         return Discrete{promote_type(T1,T2)}(x)

--- a/src/types/TransferFunction.jl
+++ b/src/types/TransferFunction.jl
@@ -22,7 +22,6 @@ end
 #     return TransferFunction(matrix, Continuous())
 # end
 
-time(G) = G.time
 
 noutputs(G::TransferFunction) = size(G.matrix, 1)
 ninputs(G::TransferFunction) = size(G.matrix, 2)
@@ -183,7 +182,7 @@ function Base.show(io::IO, G::TransferFunction)
     if iscontinuous(G)
         print(io, "\nContinuous-time transfer function model")
     elseif isdiscrete(G)
-        print(io, "\nSample Time: ", G.Ts, " (seconds)")
+        print(io, "\nSample Time: ", sampletime(G), " (seconds)")
         print(io, "\nDiscrete-time transfer function model")
     else
         print(io, "\nStatic gain transfer function model")

--- a/src/types/conversion.jl
+++ b/src/types/conversion.jl
@@ -20,9 +20,9 @@
 # Base.convert(::Type{<:TransferFunction{<:SisoZpk}}, b::Number) = zpk(b)
 #
 Base.convert(::Type{TransferFunction{TimeT,SisoZpk{T1, TR1}}}, b::AbstractMatrix{T2}) where {TimeT, T1, TR1, T2<:Number} =
-    zpk(T1.(b), undef_sampleperiod(TimeT))
+    zpk(T1.(b), undef_sampletime(TimeT))
 Base.convert(::Type{TransferFunction{TimeT,SisoRational{T1}}}, b::AbstractMatrix{T2}) where {TimeT, T1, T2<:Number} =
-    tf(T1.(b), undef_sampleperiod(TimeT))
+    tf(T1.(b), undef_sampletime(TimeT))
 
 function convert(::Type{StateSpace{TimeT,T,MT}}, D::AbstractMatrix{<:Number}) where {TimeT,T, MT}
     (ny, nu) = size(D)
@@ -30,14 +30,14 @@ function convert(::Type{StateSpace{TimeT,T,MT}}, D::AbstractMatrix{<:Number}) wh
     B = MT(fill(zero(T), (0,nu)))
     C = MT(fill(zero(T), (ny,0)))
     D = convert(MT, D)
-    return StateSpace{TimeT,T,MT}(A,B,C,D,undef_sampleperiod(TimeT))
+    return StateSpace{TimeT,T,MT}(A,B,C,D,undef_sampletime(TimeT))
 end
 
 # TODO We still dont have TransferFunction{..}(number/array) constructors
 Base.convert(::Type{TransferFunction{TimeT,SisoRational{T}}}, b::Number) where {TimeT, T} =
-    tf(T(b), undef_sampleperiod(TimeT))
+    tf(T(b), undef_sampletime(TimeT))
 Base.convert(::Type{TransferFunction{TimeT,SisoZpk{T,TR}}}, b::Number) where {TimeT, T, TR} =
-    zpk(T(b), undef_sampleperiod(TimeT))
+    zpk(T(b), undef_sampletime(TimeT))
 Base.convert(::Type{StateSpace{TimeT,T,MT}}, b::Number) where {TimeT, T, MT} =
     convert(StateSpace{TimeT,T,MT}, fill(b, (1,1)))
 #

--- a/test/test_connections.jl
+++ b/test/test_connections.jl
@@ -157,10 +157,16 @@ arr4[1] = ss(0); arr4[2] = ss(1); arr4[3] = ss(2)
 # Type and sample time
 @test [D_111 1.0] isa StateSpace{Discrete{Float64},Float64,Array{Float64,2}}
 @test [D_111 1.0].Ts == 0.005
+@test sampletime([D_111 1.0]) == 0.005
 # Continuous version
 @test [C_111 1.0] == ss([1.0], [2.0 0.0], [3.0], [4.0 1.0])
 @test [1.0 C_111] == ss([1.0], [0.0 2.0], [3.0], [1.0 4.0])
 @test [C_111 1.0] isa StateSpace{Continuous,Float64,Array{Float64,2}}
+@test [C_111 1.0].Ts == 0.0
+@test_logs (:warn,
+            "Getting time 0.0 for non-discrete systems is deprecated. Check `isdiscrete` before trying to access time."
+            ) [C_111 1.0].Ts
+@test_throws ErrorException ControlSystems.sampletime([C_111 1.0])
 # Concatenation of discrete system with matrix
 @test [D_222 fill(1.5, 2, 2)] == [D_222 ss(fill(1.5, 2, 2),0.005)]
 @test [C_222 fill(1.5, 2, 2)] == [C_222 ss(fill(1.5, 2, 2))]

--- a/test/test_delayed_systems.jl
+++ b/test/test_delayed_systems.jl
@@ -132,9 +132,6 @@ w = 10 .^ (-2:0.1:2)
 @test freqresp(s11, w) ≈ freqresp(f2[1,1], w) rtol=1e-15
 
 
-@test propertynames(delay(1.0)) == (:P, :Tau)
-
-
 #FIXME: A lot more tests, including MIMO systems in particular
 
 # Test step

--- a/test/test_partitioned_statespace.jl
+++ b/test/test_partitioned_statespace.jl
@@ -38,5 +38,3 @@ sys2 = ControlSystems.PartionedStateSpace(ss(fill(1.0, 2, 2), fill(2.0, 2, 5), f
 
 # TODO: Add some tests for interconnections, implicitly tested through delay system implementations though
 @test (sys1 + sys1).P[1, 1] == (sys1.P[1,1] + sys1.P[1,1])
-
-@test propertynames(sys1) == (:P, :nu1, :ny1)

--- a/test/test_statespace.jl
+++ b/test/test_statespace.jl
@@ -101,9 +101,6 @@
         # Accessing Ts through .Ts
         @test D_111.Ts == 0.005
 
-        # propertynames
-        propertynames(C_111) = (:A, :B, :C, :D, :nx, :nu, :ny, :Ts)
-        propertynames(D_111) = (:A, :B, :C, :D, :nx, :nu, :ny)
 
         # Printing
         if SS <: StateSpace

--- a/test/test_transferfunction.jl
+++ b/test/test_transferfunction.jl
@@ -93,10 +93,6 @@ tf(vecarray(1, 2, [0], [0]), vecarray(1, 2, [1], [1]), 0.005)
 # Accessing Ts through .Ts
 @test D_111.Ts == 0.005
 
-# propertynames
-@test propertynames(C_111) == (:matrix, :nu, :ny)
-@test propertynames(D_111) == (:matrix, :nu, :ny, :Ts)
-
 
 # Errors
 @test_throws ErrorException tf(vecarray(1, 1, [1,7,13,15]),


### PR DESCRIPTION
Alternative names to suggestion https://github.com/JuliaControl/ControlSystems.jl/pull/294
Chnages:
* Exports `sampletime(sys)` and uses it internally instead of `sys.Ts` to simplify interface which throw errors when the system is `Continous`. (It is still possible to use `.Ts`, but it throws a warning on `Continous` systems)
* Interface: `time(sys)` for `LTISystems`
  * New `<:LTISystem` systems only need to define `time(sys)` to get working `sampletime, isdiscrete, iscountinous, common_time`
  * Defaults to `sys.time`
  * In the context of general `LTISystems` it is only used in the fallbacks for the above mentioned functions, and once as `typeof(time(sys))` in `zpkdata`.
* `UNDEF_SAMPLEPERIOD` to `UNDEF_SAMPLETIME`
* Removed `timetype(sys)`, it was only used once, and can be replaced by `typeof(time(sys))`
* Removed hiding of the field `time`. I am open to adding back `Ts` to `propertynames` to make autocompletion easier.

Possible additional changes:

Chage the internal functions that have `AbstractStateSpace` to as inputs to use `time(sys)` instead of `sys.time` to make it robust to new types `<:AbstractStateSpace`. However, this is not nessesary since all current implementations have the field `time`, and new implementations could implement `getproperty`.

Edit: I am open to changing `.time` and `time(sys)` to `timedomain`.