### PR TITLE
Leaner promotion mechanism in evalfr

### DIFF
--- a/src/freqresp.jl
+++ b/src/freqresp.jl
@@ -39,6 +39,11 @@ function _preprocess_for_freqresp(sys::StateSpace)
 end
 
 
+function _evalfr_return_type(sys::AbstractStateSpace, s::Number)
+    temp_product = one(T0)*one(typeof(s))
+    typeof(temp_product/temp_product)
+end
+
 """
 `evalfr(sys, x)` Evaluate the transfer function of the LTI system sys
 at the complex number s=x (continuous-time) or z=x (discrete-time).
@@ -47,7 +52,7 @@ For many values of `x`, use `freqresp` instead.
 """
 function evalfr(sys::StateSpace{<:TimeEvolution,T0}, s::Number) where {T0}
     prod = one(T0)*one(typeof(s))
-    T = typeof(prod/prod)
+    T = _evalfr_return_type(sys, s)
     try
         R = s*I - sys.A
         sys.D + sys.C*((R\sys.B)::Matrix{T})  # Weird type stability issue

--- a/src/freqresp.jl
+++ b/src/freqresp.jl
@@ -51,7 +51,6 @@ at the complex number s=x (continuous-time) or z=x (discrete-time).
 For many values of `x`, use `freqresp` instead.
 """
 function evalfr(sys::StateSpace{<:TimeEvolution,T0}, s::Number) where {T0}
-    prod = one(T0)*one(typeof(s))
     T = _evalfr_return_type(sys, s)
     try
         R = s*I - sys.A

--- a/src/freqresp.jl
+++ b/src/freqresp.jl
@@ -46,7 +46,8 @@ at the complex number s=x (continuous-time) or z=x (discrete-time).
 For many values of `x`, use `freqresp` instead.
 """
 function evalfr(sys::StateSpace{<:TimeEvolution,T0}, s::Number) where {T0}
-    T = promote_type(T0, typeof(one(T0)*one(typeof(s))/(one(T0)*one(typeof(s)))))
+    prod = one(T0)*one(typeof(s))
+    T = typeof(prod/prod)
     try
         R = s*I - sys.A
         sys.D + sys.C*((R\sys.B)::Matrix{T})  # Weird type stability issue

--- a/src/freqresp.jl
+++ b/src/freqresp.jl
@@ -39,7 +39,7 @@ function _preprocess_for_freqresp(sys::StateSpace)
 end
 
 
-function _evalfr_return_type(sys::AbstractStateSpace, s::Number)
+function _evalfr_return_type(sys::StateSpace{<:TimeEvolution,T0}, s::Number) where {T0}
     temp_product = one(T0)*one(typeof(s))
     typeof(temp_product/temp_product)
 end


### PR DESCRIPTION
The old promotion code cause some issues with special types. It might also be the case that 
```
one(T0)*one(typeof(s))
prod/prod
```
is expensive to evaluate, in which case we would really like to avoid doing computations just to figure out the type.

I don't know why the old promotion code was so complicated, but the tests pass (locally at least)  with this new one. Anyone have strong feelings for the old promotion? Blame indicates mattias as the last author
https://github.com/JuliaControl/ControlSystems.jl/blame/7fc5ba4b0ab511b699b5c280e5e0e68c52fe07c0/src/freqresp.jl