### PR TITLE
warning and typing in freqresp for statespace

### DIFF
--- a/src/freqresp.jl
+++ b/src/freqresp.jl
@@ -56,7 +56,6 @@ function evalfr(sys::AbstractStateSpace, s::Number)
     try
         R = s*I - sys.A
         sys.D + sys.C*((R\sys.B))
-        sys.D + sys.C*((R\sys.B)::Matrix{T})  # Weird type stability issue
     catch e
         @warn "Got exception $e, returning Inf" max_log=1
         fill(convert(T, Inf), size(sys))

--- a/src/freqresp.jl
+++ b/src/freqresp.jl
@@ -39,7 +39,8 @@ function _preprocess_for_freqresp(sys::StateSpace)
 end
 
 
-function _evalfr_return_type(sys::StateSpace{<:TimeEvolution,T0}, s::Number) where {T0}
+function _evalfr_return_type(sys::AbstractStateSpace, s::Number)
+    T0 = numeric_type(sys)
     temp_product = one(T0)*one(typeof(s))
     typeof(temp_product/temp_product)
 end
@@ -50,12 +51,14 @@ at the complex number s=x (continuous-time) or z=x (discrete-time).
 
 For many values of `x`, use `freqresp` instead.
 """
-function evalfr(sys::StateSpace{<:TimeEvolution,T0}, s::Number) where {T0}
+function evalfr(sys::AbstractStateSpace, s::Number)
     T = _evalfr_return_type(sys, s)
     try
         R = s*I - sys.A
+        sys.D + sys.C*((R\sys.B))
         sys.D + sys.C*((R\sys.B)::Matrix{T})  # Weird type stability issue
-    catch
+    catch e
+        @warn "Got exception $e, returning Inf" max_log=1
         fill(convert(T, Inf), size(sys))
     end
 end


### PR DESCRIPTION
`_evalfr_return_type` to accept `AbstractStateSpace` and issue a warning about the exception received if factorization fails. The `max_log=1` makes the warning appear only once, as opposed to for all frequencies in a frequency vector.