### PR TITLE
Make time vector to lsim optional

### DIFF
--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -70,7 +70,7 @@ impulse(sys::LTISystem, Tf::Real; kwags...) = impulse(sys, _default_time_vector(
 impulse(sys::LTISystem; kwags...) = impulse(sys, _default_time_vector(sys); kwags...)
 impulse(sys::TransferFunction, t::AbstractVector; kwags...) = impulse(ss(sys), t; kwags...)
 
-"""`y, t, x = lsim(sys, u, t; x0, method])`
+"""`y, t, x = lsim(sys, u[, t]; x0, method])`
 
 `y, t, x, uout = lsim(sys, u::Function, t; x0, method)`
 
@@ -134,6 +134,11 @@ function lsim(sys::StateSpace, u::AbstractVecOrMat, t::AbstractVector;
     x = ltitr(dsys.A, dsys.B, u, x0)
     y = transpose(sys.C*transpose(x) + sys.D*transpose(u))
     return y, t, x
+end
+
+function lsim(sys::StateSpace{<:Discrete}, u::AbstractVecOrMat; kwargs...)
+    t = range(0, length=length(u), step=sys.Ts)
+    lsim(sys, u, t; kwargs...)
 end
 
 @deprecate lsim(sys, u, t, x0) lsim(sys, u, t; x0=x0)

--- a/test/test_timeresp.jl
+++ b/test/test_timeresp.jl
@@ -43,6 +43,13 @@ yd, td, xd = lsim(sysd, u, t, x0=x0)
 @test norm(y - yd)/norm(y) < 0.05 # Since the cost matrices are not discretized, these will differ a bit
 @test norm(x - xd)/norm(x) < 0.05
 
+# Test lsim with default time vector
+uv = randn(length(t))
+y,t = lsim(c2d(sys,0.1)[1],uv,t,x0=x0)
+yd,td = lsim(c2d(sys,0.1)[1],uv,x0=x0)
+@test yd == y
+@test td == t
+
 #Test step and impulse Continuous
 t0 = 0:0.05:2
 systf = [tf(1,[1,1]) 0; 0 tf([1,-1],[1,2,1])]


### PR DESCRIPTION
This PR adds a convenience method that supplies a default time vector to `lsim` for discrete systems when a vector of inputs is supplied.