### PR TITLE
WIP: Add basic logic to avoid delays in series for DelayLtiSystem

### DIFF
--- a/src/types/DelayLtiSystem.jl
+++ b/src/types/DelayLtiSystem.jl
@@ -118,7 +118,7 @@ Base.size(sys::DelayLtiSystem) = (noutputs(sys), ninputs(sys))
 # Fallbacks, TODO We should sort this out for all types, maybe after SISO/MIMO
 # {Array, Number}, Colon
 Base.getindex(sys::DelayLtiSystem, i, ::Colon) =
-    getindex(sys, index2range(i), 1:size(sys,2g;))
+    getindex(sys, index2range(i), 1:size(sys,2))
 # Colon, {Array, Number}
 Base.getindex(sys::DelayLtiSystem, ::Colon, j) =
     getindex(sys, 1:size(sys,1), index2range(j))


### PR DESCRIPTION
There was an issue where delay(1)*delay(1) generated a system which could not be simulated since it has a D22 matrix which is non-zero.

For the moment my goal was just to see if I could get it to work with delay(1)*delay(1) being simplified to the same as delay(2), and it seems to work. I know the code is not very nice, but wanted some input on if this is at all useful or compatible with how the rest works before I spend more time on it.

It basically just checks if there is any delay which only depends on a single other delay, and nothing else depends on that delay.