### PR TITLE
Only run travis once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ matrix:
   fast_finish: true
 notifications:
     email: false
+branches:
+  only: 
+    - master
 addons:
   apt:
     packages:


### PR DESCRIPTION
This should hopefully prevent travis from building once for PRs and once for branches, except for on master.