### PR TITLE
WIP: Added DAE version of DDE system

### DIFF
--- a/src/delay_systems.jl
+++ b/src/delay_systems.jl
@@ -95,7 +95,7 @@ function lsim(sys::DelayLtiSystem{T,S}, u, t::AbstractArray{<:Real}; x0=fill(zer
         _lsim(sys, u!, t, x0, alg; kwargs...)
     else
         @warn("Non-zero D22-matrix block in delayed system: results will be inaccurate. Algorithm set to MethodOfSteps(ImplicitEuler())")
-        _lsim_dae(sys, u!, t, x0, MethodOfSteps(ImplicitEuler()); kwargs...)
+        _lsim_dae(sys, u!, t, x0, MethodOfSteps(ImplicitEuler(autodiff=false)); kwargs...)
     end
 end
 


### PR DESCRIPTION
This is an implementation of lsim for `DelayLTISystem` where the differential equation is solved as an Delay-DAE instead of a DDE.
It works, in particular also when `D22 /= 0`, but the numerical performance is pretty bad. Posted here for reference.