### PR TITLE
Order zpk poles in constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -37,4 +37,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 
 [targets]
-test = ["Test", "Documenter", "GR", "StaticArrays"]
+test = ["Test", "Documenter", "GR", "StaticArrays", "DSP"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.8.0"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
-DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 DelayDiffEq = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
@@ -21,7 +20,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 Colors = "0.9.2, 0.10, 0.11, 0.12"
-DSP = "0.6.1"
 DelayDiffEq = "5.6"
 IterTools = "1.0"
 LaTeXStrings = "1.0"
@@ -33,9 +31,10 @@ julia = "1.0"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 GR = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 
 [targets]
 test = ["Test", "Documenter", "GR", "StaticArrays"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@
 ENV["PLOTS_TEST"] = "true"
 ENV["GKSwstype"] = "100"
 
-using Documenter, ControlSystems, Plots, LinearAlgebra, DSP
+using Documenter, ControlSystems, Plots, LinearAlgebra
 import GR # Bug with world age in Plots.jl, see https://github.com/JuliaPlots/Plots.jl/issues/1047
 gr()
 default(show=false, size=(800,450))

--- a/src/ControlSystems.jl
+++ b/src/ControlSystems.jl
@@ -104,7 +104,6 @@ import Base: exp # for exp(-s)
 import LinearAlgebra: BlasFloat
 export lyap # Make sure LinearAlgebra.lyap is available
 import Printf, Colors
-import DSP: conv
 using MacroTools
 
 abstract type AbstractSystem end

--- a/src/discrete.jl
+++ b/src/discrete.jl
@@ -218,14 +218,3 @@ function c2d(G::TransferFunction, h;kwargs...)
     sysd = c2d(sys, h, kwargs...)[1]
     return convert(TransferFunction, sysd)
 end
-
-"""
-`zpc(a,r,b,s)` form conv(a,r) + conv(b,s) where the lengths of the polynomials are equalized by zero-padding such that the addition can be carried out
-"""
-function zpconv(a,r,b,s)
-    d = length(a)+length(r)-length(b)-length(s)
-    if d > 0
-        b = [zeros(d);b]
-    end
-    conv(a,r) + conv(b,s)
-end

--- a/src/types/SisoTfTypes/SisoZpk.jl
+++ b/src/types/SisoTfTypes/SisoZpk.jl
@@ -12,9 +12,9 @@ struct SisoZpk{T,TR<:Number} <: SisoTf{T}
             z = TR[]
         end
         if TR <: Complex && T <: Real
-            sort_conjugates!(z)
+            order_conjugates!(z)
             @assert check_real(z) "zpk model should be real-valued, but zeros do not come in conjugate pairs."
-            sort_conjugates!(p)
+            order_conjugates!(p)
             @assert check_real(p) "zpk model should be real-valued, but poles do not come in conjugate pairs."
         end
         new{T,TR}(z, p, k)
@@ -197,18 +197,18 @@ function print_siso(io::IO, t::SisoZpk, var=:s)
     println(io, denstr)
 end
 
-function sort_conjugates!(x)
+function order_conjugates!(x)
     i = 0
     while i < length(x)
         i += 1
         imag(x[i]) == 0 && continue
         for j in i+1:length(x)
             if x[i] == conj(x[j])
-                if imag(x[i]) > imag(x[j])
+                if imag(x[i]) > imag(x[j]) # Swap i+1 <-> j
                     tmp = x[i+1]
                     x[i+1] = x[j]
                     x[j] = tmp
-                else
+                else # Rotate i -> i+1 -> j -> i
                     tmp = x[i]
                     x[i] = x[j]
                     x[j] = x[i+1]

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -206,7 +206,7 @@ function extractvarname(a)
 end
 
 """
-`conv(a,b)` makes a convolution between vectors `a` and `b`
+`conv(a,b)` creates a convolution of vectors `a` and `b`
 """
 function conv(a::AbstractArray{T}, b::AbstractArray{S}) where {T, S}
     n, m = length(a), length(b) 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -204,3 +204,27 @@ end
 function extractvarname(a)
     typeof(a) == Symbol ? a : extractvarname(a.args[1])
 end
+
+"""
+`conv(a,b)` makes a convolution between vectors `a` and `b`
+"""
+function conv(a::AbstractArray{T}, b::AbstractArray{S}) where {T, S}
+    n, m = length(a), length(b) 
+    R = promote_type(T, S)
+    c = zeros(R, m + n - 1)
+    for i in 1:n, j in 1:m
+        @inbounds c[i + j - 1] += a[i] * b[j]
+    end
+    return c
+end
+
+"""
+`zpconv(a,r,b,s)` form conv(a,r) + conv(b,s) where the lengths of the polynomials are equalized by zero-padding such that the addition can be carried out
+"""
+function zpconv(a,r,b,s)
+    d = length(a)+length(r)-length(b)-length(s)
+    if d > 0
+        b = [zeros(d);b]
+    end
+    conv(a,r) + conv(b,s)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test, LinearAlgebra, Random
 using Documenter            # For doctests
 import Base.isapprox        # In framework and test_synthesis
 import SparseArrays: sparse # In test_matrix_comps
-import DSP: conv            # In test_conversion and test_synthesis
+import ControlSystems: conv            # In test_conversion and test_synthesis
 include("framework.jl")
 
 # Local definition to make sure we get warnings if we use eye
@@ -35,10 +35,10 @@ my_tests = [
             ]
 
 @testset "All Tests" begin
-    println("Testing code")
-    _t0 = time()
-    run_tests(my_tests)
-    println("Ran all code tests in $(round(time()-_t0, digits=2)) seconds")
+    #println("Testing code")
+    #_t0 = time()
+    #run_tests(my_tests)
+    #println("Ran all code tests in $(round(time()-_t0, digits=2)) seconds")
 
 
     println("Test Doctests")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,10 +35,10 @@ my_tests = [
             ]
 
 @testset "All Tests" begin
-    #println("Testing code")
-    #_t0 = time()
-    #run_tests(my_tests)
-    #println("Ran all code tests in $(round(time()-_t0, digits=2)) seconds")
+    println("Testing code")
+    _t0 = time()
+    run_tests(my_tests)
+    println("Ran all code tests in $(round(time()-_t0, digits=2)) seconds")
 
 
     println("Test Doctests")


### PR DESCRIPTION
Add `order_conjugates!` to pair up and order poles/zeros in the order LAPACK uses (positive imaginary part first followed by conjugate) and call it in constructor for SisoZpk type if there are complex poles/zeros.

Ordering only cares about pairing up exact conjugates and putting them in the desired order, and leaves other things as it is. It also skips a complex number if there is no conjugate, which will then be caught by `check_real` which is called right after. 

From #369 I though that there could be numerical problems that forced us to assume conjugates might not match perfectly, but I believe after discussing with @mfalt that this was a misunderstanding from my side and that we can assume the correct conjugate always exists exactly in our internal transformations. And assuming that the user supplies exact conjugates is reasonable to me so I implemented this under the assumption that there will be exact matches, else it will error in `check_real`.