### PR TITLE
Add function to order conjugate pairs in zpk constructor

### DIFF
--- a/src/types/SisoTfTypes/SisoZpk.jl
+++ b/src/types/SisoTfTypes/SisoZpk.jl
@@ -103,7 +103,9 @@ function minreal(sys::SisoZpk{T,TR}, eps::Real) where {T, TR}
     SisoZpk{T, TR}(newZ, newP, sys.k)
 end
 
-"""Reorder the vector x of complex numbers so that complex conjugates come after each other, with the one with positive imaginary part first. Returns true if the conjugates can be paired and otherwise false."""
+""" Reorder the vector x of complex numbers so that complex conjugates come after each other, 
+    with the one with positive imaginary part first. Returns true if the conjugates can be 
+    paired and otherwise false."""
 function pairup_conjugates!(x::AbstractVector)
     i = 0
     while i < length(x)

--- a/src/types/SisoTfTypes/SisoZpk.jl
+++ b/src/types/SisoTfTypes/SisoZpk.jl
@@ -109,22 +109,19 @@ function pairup_conjugates!(x::AbstractVector)
     while i < length(x)
         i += 1
         imag(x[i]) == 0 && continue
-        foundconj = false
-        for j in i+1:length(x)
-            if x[i] == conj(x[j])
-                if imag(x[i]) > imag(x[j]) # Swap i+1 <-> j
-                    tmp = x[i+1]
-                    x[i+1] = x[j]
-                    x[j] = tmp
-                else # Rotate i -> i+1 -> j -> i
-                    tmp = x[i]
-                    x[i] = x[j]
-                    x[j] = x[i+1]
-                    x[i+1] = tmp
-                end
-                foundconj = true
-                break
-            end
+
+        # Attempt to find a matching conjugate to x[i]
+        j = findnext(==(conj(x[i])), x, i+1)
+        j === nothing && return false
+
+        tmp = x[j]
+        x[j] = x[i+1]
+        # Make sure that the complex number with positive imaginary part comes first
+        if imag(x[i]) > 0
+            x[i+1] = tmp
+        else
+            x[i+1] = x[i]
+            x[i] = tmp
         end
         if !foundconj 
             return false

--- a/src/types/SisoTfTypes/SisoZpk.jl
+++ b/src/types/SisoTfTypes/SisoZpk.jl
@@ -104,7 +104,7 @@ function minreal(sys::SisoZpk{T,TR}, eps::Real) where {T, TR}
 end
 
 """Reorder the vector x of complex numbers so that complex conjugates come after each other, with the one with positive imaginary part first. Returns true if the conjugates can be paired and otherwise false."""
-function pairup_conjugates!(x)
+function pairup_conjugates!(x::AbstractVector)
     i = 0
     while i < length(x)
         i += 1

--- a/src/types/SisoTfTypes/SisoZpk.jl
+++ b/src/types/SisoTfTypes/SisoZpk.jl
@@ -6,19 +6,20 @@ struct SisoZpk{T,TR<:Number} <: SisoTf{T}
     z::Vector{TR}
     p::Vector{TR}
     k::T
-    function SisoZpk{T,TR}(z::Vector{TR}, p::Vector{TR}, k::T) where  {T<:Number, TR<:Number}
+    function SisoZpk{T,TR}(z::Vector{TR}, p::Vector{TR}, k::T) where {T<:Number, TR<:Number}
         if k == zero(T)
             p = TR[]
             z = TR[]
         end
         if TR <: Complex && T <: Real
+            z, p = copy(z), copy(p)
             @assert pairup_conjugates!(z) "zpk model should be real-valued, but zeros do not come in conjugate pairs."
             @assert pairup_conjugates!(p) "zpk model should be real-valued, but poles do not come in conjugate pairs."
         end
         new{T,TR}(z, p, k)
     end
 end
-function SisoZpk{T,TR}(z::Vector, p::Vector, k::Number) where  {T<:Number, TR<:Number}
+function SisoZpk{T,TR}(z::Vector, p::Vector, k::Number) where {T<:Number, TR<:Number}
     SisoZpk{T,TR}(Vector{TR}(z), Vector{TR}(p), T(k))
 end
 function SisoZpk{T}(z::Vector, p::Vector, k::Number) where T

--- a/src/types/SisoTfTypes/SisoZpk.jl
+++ b/src/types/SisoTfTypes/SisoZpk.jl
@@ -103,8 +103,7 @@ function minreal(sys::SisoZpk{T,TR}, eps::Real) where {T, TR}
     SisoZpk{T, TR}(newZ, newP, sys.k)
 end
 
-""" If TR is Complex and T is Real, pair up every pole with its conjugate as they are ordered 
-    by the LAPACK routines that return complex-conjugated values, i.e., (x+iy) is followed by (x-iy)"""
+"""Reorder the vector x of complex numbers so that complex conjugates come after each other, with the one with positive imaginary part first. Returns true if the conjugates can be paired and otherwise false."""
 function pairup_conjugates!(x)
     i = 0
     while i < length(x)

--- a/src/types/SisoTfTypes/SisoZpk.jl
+++ b/src/types/SisoTfTypes/SisoZpk.jl
@@ -123,9 +123,6 @@ function pairup_conjugates!(x::AbstractVector)
             x[i+1] = x[i]
             x[i] = tmp
         end
-        if !foundconj 
-            return false
-        end
         i += 1 # Since it is a pair and the conjugate was found
     end
     return true

--- a/test/test_zpk.jl
+++ b/test/test_zpk.jl
@@ -38,6 +38,9 @@ z = zpk("z", 0.005)
 @test zpk([], [], 1.0) == zpk(Float64[], Float64[], 1.0)
 @test zpk([], [1.0+im,1.0-im], 1.0) == zpk(ComplexF64[], [1.0+im,1.0-im], 1.0)
 
+# Test constructors with different conjugate ordering
+@test zpk([], [1.0-im,1.0+im], 1.0) == zpk(ComplexF64[], [1.0+im,1.0-im], 1.0)
+@test zpk([], [1.0+im,1.0,1.0-im], 1.0) == zpk(ComplexF64[], [1.0+im,1.0-im,1.0], 1.0)
 
 
 #TODO improve polynomial accuracy se these are equal

--- a/test/test_zpk.jl
+++ b/test/test_zpk.jl
@@ -41,6 +41,9 @@ z = zpk("z", 0.005)
 # Test constructors with different conjugate ordering
 @test zpk([], [1.0-im,1.0+im], 1.0) == zpk(ComplexF64[], [1.0+im,1.0-im], 1.0)
 @test zpk([], [1.0+im,1.0,1.0-im], 1.0) == zpk(ComplexF64[], [1.0+im,1.0-im,1.0], 1.0)
+@test zpk([1.0-im,1.0,1.0+im], [], 1.0) == zpk([1.0+im,1.0-im,1.0], ComplexF64[], 1.0)
+@test zpk([], [1.0+im,1.0,1.0+im,1.0-im,1.0-im], 1.0) == zpk(ComplexF64[], [1.0+im,1.0-im,1.0+im,1.0-im,1.0], 1.0)
+@test_throws AssertionError zpk([], [1.01+im,1.0-im], 1.0) 
 
 
 #TODO improve polynomial accuracy se these are equal


### PR DESCRIPTION
Add `order_conjugates!` to pair up and order poles/zeros in the order LAPACK uses (positive imaginary part first followed by conjugate) and call it in constructor for SisoZpk type if there are complex poles/zeros.

Ordering only cares about pairing up exact conjugates and putting them in the desired order, and leaves other things as it is. It also skips a complex number if there is no conjugate, which will then be caught by `check_real` which is called right after. 

From #369 I though that there could be numerical problems that forced us to assume conjugates might not match perfectly, but I believe after discussing with @mfalt that this was a misunderstanding from my side and that we can assume the correct conjugate always exists exactly in our internal transformations. And assuming that the user supplies exact conjugates is reasonable to me so I implemented this under the assumption that there will be exact matches, else it will error in `check_real`.