### PR TITLE
Add Manifest.toml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 docs/build/
 docs/site/
+
+Manifest.toml


### PR DESCRIPTION
I just felt that either the Manifest.toml should be checked in to the repo or it should be in the .gitignore file, I don't really see any reason why it should not be one of those two cases. 

I found a short discourse thread on this [here](https://discourse.julialang.org/t/does-manifest-toml-belong-in-the-repository/12029/12) where there are some mixed opinions, but it seems that most people agree that for a package it is not really necessary. Someone also brings up the point that it might actually be good to have developers have slightly different versions of dependencies to have our package tested over a wider variety of environments, but also brings up the value of having a history of working Manifests stored in the repo.

I'm leaning more towards adding it to the ignore (hence the PR) but mostly feel that just doing either is nicer than having untracked unignored generated files in the repo.