### PR TITLE
removed multiplication sign in tf print

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ LaTeXStrings = "1.0"
 MacroTools = "0.5"
 OrdinaryDiffEq = "5.2"
 Plots = "0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 1.0"
-Polynomials = "1.0"
+Polynomials = "1.1.10"
 julia = "1.0"
 
 [extras]

--- a/docs/src/examples/example.md
+++ b/docs/src/examples/example.md
@@ -107,9 +107,9 @@ P  = tf(B,A)
 # output
 
 TransferFunction{Continuous,ControlSystems.SisoRational{Float64}}
-         1.0
----------------------
-1.0*s^2 + 0.4*s + 1.0
+        1.0
+-------------------
+1.0s^2 + 0.4s + 1.0
 
 Continuous-time transfer function model
 ```

--- a/docs/src/man/creating_systems.md
+++ b/docs/src/man/creating_systems.md
@@ -18,9 +18,9 @@ tf([1.0],[1,2,1])
 # output
 
 TransferFunction{Continuous,ControlSystems.SisoRational{Float64}}
-         1.0
----------------------
-1.0*s^2 + 2.0*s + 1.0
+        1.0
+-------------------
+1.0s^2 + 2.0s + 1.0
 
 Continuous-time transfer function model
 ```
@@ -40,9 +40,9 @@ zpk([-1.0,1], [-5, -10], 2)
 # output
 
 TransferFunction{Continuous,ControlSystems.SisoZpk{Float64,Float64}}
-   (1.0*s + 1.0)(1.0*s - 1.0)
-2.0---------------------------
-   (1.0*s + 5.0)(1.0*s + 10.0)
+   (1.0s + 1.0)(1.0s - 1.0)
+2.0-------------------------
+   (1.0s + 5.0)(1.0s + 10.0)
 
 Continuous-time transfer function model
 ```
@@ -57,9 +57,9 @@ tf(zpk([-1], [1], 2, 0.1))
 # output
 
 TransferFunction{Discrete{Float64},ControlSystems.SisoRational{Int64}}
-2*z + 2
--------
- z - 1
+2z + 2
+------
+z - 1
 
 Sample Time: 0.1 (seconds)
 Discrete-time transfer function model

--- a/docs/src/man/introduction.md
+++ b/docs/src/man/introduction.md
@@ -28,9 +28,9 @@ T = P/(1+P)
 # output
 
 TransferFunction{Continuous,ControlSystems.SisoRational{Float64}}
-     1.0*s + 1.0
----------------------
-1.0*s^2 + 3.0*s + 2.0
+    1.0s + 1.0
+-------------------
+1.0s^2 + 3.0s + 2.0
 
 Continuous-time transfer function model
 ```
@@ -42,9 +42,9 @@ minreal(T)
 # output
 
 TransferFunction{Continuous,ControlSystems.SisoRational{Float64}}
-    1.0
------------
-1.0*s + 2.0
+   1.0
+----------
+1.0s + 2.0
 
 Continuous-time transfer function model
 ```

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -54,7 +54,7 @@ end
 """ f = printpolyfun(var)
 `fun` Prints polynomial in descending order, with variable `var`
 """
-printpolyfun(var) = (io, p, mimetype = MIME"text/plain"()) -> Polynomials.printpoly(io, Polynomial(p.coeffs, var), mimetype, descending_powers=true)
+printpolyfun(var) = (io, p, mimetype = MIME"text/plain"()) -> Polynomials.printpoly(io, Polynomial(p.coeffs, var), mimetype, descending_powers=true, mulsymbol="")
 
 # NOTE: Tolerances for checking real-ness removed, shouldn't happen from LAPACK?
 # TODO: This doesn't play too well with dual numbers..

--- a/test/test_transferfunction.jl
+++ b/test/test_transferfunction.jl
@@ -104,10 +104,10 @@ tf(vecarray(1, 2, [0], [0]), vecarray(1, 2, [1], [1]), 0.005)
 
 
 # Printing
-res = ("TransferFunction{Continuous,ControlSystems.SisoRational{Int64}}\nInput 1 to Output 1\ns^2 + 2s + 3\n-------------\ns^2 + 8s + 15\n\nInput 1 to Output 2\ns^2 + 2s + 3\n-------------\ns^2 + 8s + 15\n\nInput 2 to Output 1\n    s + 2\n-------------\ns^2 + 8s + 15\n\nInput 2 to Output 2\n    s + 2\n-------------\ns^2 + 8s + 15\n\nContinuous-time transfer function model")
-@test_broken sprint(show, C_222) == res
-res = ("TransferFunction{Continuous,ControlSystems.SisoRational{Int64}}\nInput 1 to Output 1\nz^2 + 2.0z + 3.0\n-----------------\nz^2 - 0.2z - 0.15\n\nInput 1 to Output 2\nz^2 + 2.0z + 3.0\n-----------------\nz^2 - 0.2z - 0.15\n\nInput 2 to Output 1\n     z + 2.0\n-----------------\nz^2 - 0.2z - 0.15\n\nInput 2 to Output 2\n     z + 2.0\n-----------------\nz^2 - 0.2z - 0.15\n\nSample Time: 0.005 (seconds)\nDiscrete-time transfer function model")
-@test_broken sprint(show, D_222) == res
+res = ("TransferFunction{Continuous,ControlSystems.SisoRational{Int64}}\nInput 1 to output 1\ns^2 + 2s + 3\n-------------\ns^2 + 8s + 15\n\nInput 1 to output 2\ns^2 + 2s + 3\n-------------\ns^2 + 8s + 15\n\nInput 2 to output 1\n    s + 2\n-------------\ns^2 + 8s + 15\n\nInput 2 to output 2\n    s + 2\n-------------\ns^2 + 8s + 15\n\nContinuous-time transfer function model")
+@test sprint(show, C_222) == res
+res = ("TransferFunction{Discrete{Float64},ControlSystems.SisoRational{Float64}}\nInput 1 to output 1\n1.0z^2 + 2.0z + 3.0\n--------------------\n1.0z^2 - 0.2z - 0.15\n\nInput 1 to output 2\n1.0z^2 + 2.0z + 3.0\n--------------------\n1.0z^2 - 0.2z - 0.15\n\nInput 2 to output 1\n     1.0z + 2.0\n--------------------\n1.0z^2 - 0.2z - 0.15\n\nInput 2 to output 2\n     1.0z + 2.0\n--------------------\n1.0z^2 - 0.2z - 0.15\n\nSample Time: 0.005 (seconds)\nDiscrete-time transfer function model")
+@test sprint(show, D_222) == res
 
 
 @test tf(zpk([1.0 2; 3 4])) == tf([1 2; 3 4])


### PR DESCRIPTION
With a recent change in Polynomials.jl we are now able to print transferfunctions without the multiplication sign. I think this was how we used to have it, and we had some "broken" tests for this.
See diff for examples. 

Edit: It would be nice to also change so that we print `s+2.0` instead of `1.0s+2.0` but I don't see how that is possible without overriding their internal `showone(::Type{T}) where T` in Polynomials.jl