### PR TITLE
Fix Simulator blocking non-zero D

### DIFF
--- a/src/simulators.jl
+++ b/src/simulators.jl
@@ -38,7 +38,6 @@ plot(t, s.y(sol, t)[:], lab="Open loop step response")
 """
 function Simulator(P::AbstractStateSpace, u::F = (x,t) -> 0) where F
     @assert iscontinuous(P) "Simulator only supports continuous-time system. See function `lsim` for simulation of discrete-time systems."
-    @assert all(P.D .== 0) "Can not simulate systems with direct term D != 0"
     f = (dx,x,p,t) -> dx .= P.A*x .+ P.B*u(x,t)
     y(x,t) = P.C*x #.+ P.D*u(x,t)
     y(sol::ODESolution,t) = P.C*sol(t)

--- a/src/simulators.jl
+++ b/src/simulators.jl
@@ -40,7 +40,7 @@ function Simulator(P::AbstractStateSpace, u::F = (x,t) -> 0) where F
     @assert iscontinuous(P) "Simulator only supports continuous-time system. See function `lsim` for simulation of discrete-time systems."
     f = (dx,x,p,t) -> dx .= P.A*x .+ P.B*u(x,t)
     y(x,t) = P.C*x .+ P.D*u(x,t)
-    y(sol::ODESolution,t) = P.C*sol(t)
+    y(sol::ODESolution,t) = P.C*sol(t) .+ P.D*u(sol(t),t)
     Simulator(P, f, y)
 end
 

--- a/src/simulators.jl
+++ b/src/simulators.jl
@@ -39,7 +39,7 @@ plot(t, s.y(sol, t)[:], lab="Open loop step response")
 function Simulator(P::AbstractStateSpace, u::F = (x,t) -> 0) where F
     @assert iscontinuous(P) "Simulator only supports continuous-time system. See function `lsim` for simulation of discrete-time systems."
     f = (dx,x,p,t) -> dx .= P.A*x .+ P.B*u(x,t)
-    y(x,t) = P.C*x #.+ P.D*u(x,t)
+    y(x,t) = P.C*x .+ P.D*u(x,t)
     y(sol::ODESolution,t) = P.C*sol(t)
     Simulator(P, f, y)
 end


### PR DESCRIPTION
Remove assertion that blocks non-zero D matrices in `Simulator` type used in `lsim` according to #397 