### PR TITLE
Remove xvfb as dependancy for plotting tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ addons:
   apt:
     packages:
       - libgtk-3-dev
-      - xvfb
       - dvipng
       - texlive
 cache:
@@ -27,10 +26,8 @@ cache:
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   # Needed for plotting on travis
-  - if [[ `uname` = "Linux" ]]; then TESTCMD="xvfb-run julia"; else TESTCMD="julia"; fi
-  - $TESTCMD -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
+  - julia -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
 
 after_success:
     - julia -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
-    - if [[ `uname` = "Linux" ]]; then TESTCMD="xvfb-run julia"; else TESTCMD="julia"; fi
-    - $TESTCMD --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate();import ControlSystems; cd(joinpath(dirname(pathof(ControlSystems)), "..")); include(joinpath("docs", "make.jl"))'
+    - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate();import ControlSystems; cd(joinpath(dirname(pathof(ControlSystems)), "..")); include(joinpath("docs", "make.jl"))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ addons:
   apt:
     packages:
       - libgtk-3-dev
-      - xvfb
       - dvipng
       - texlive
 cache:
@@ -25,15 +24,12 @@ cache:
   - $HOME/.julia/artifacts
 
 env:
-  - PLOTS_TEST="true" GKSwstype="100"
+  - PLOTS_TEST="true" GKSwstype="nul"
 
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  # Needed for plotting on travis
-  - if [[ `uname` = "Linux" ]]; then TESTCMD="xvfb-run julia"; else TESTCMD="julia"; fi
-  - $TESTCMD -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
+  - julia -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
 
 after_success:
     - julia -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
-    - if [[ `uname` = "Linux" ]]; then TESTCMD="xvfb-run julia"; else TESTCMD="julia"; fi
-    - $TESTCMD --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate();import ControlSystems; cd(joinpath(dirname(pathof(ControlSystems)), "..")); include(joinpath("docs", "make.jl"))'
+    - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate();import ControlSystems; cd(joinpath(dirname(pathof(ControlSystems)), "..")); include(joinpath("docs", "make.jl"))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ cache:
   # This should speed up builds
   - $HOME/.julia/artifacts
 
-env:
-  - PLOTS_TEST="true" GKSwstype="nul"
-
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
   apt:
     packages:
       - libgtk-3-dev
+      - xvfb
       - dvipng
       - texlive
 cache:
@@ -25,8 +26,11 @@ cache:
 
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
+  # Needed for plotting on travis
+  - if [[ `uname` = "Linux" ]]; then TESTCMD="xvfb-run julia"; else TESTCMD="julia"; fi
+  - $TESTCMD -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
 
 after_success:
     - julia -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
-    - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate();import ControlSystems; cd(joinpath(dirname(pathof(ControlSystems)), "..")); include(joinpath("docs", "make.jl"))'
+    - if [[ `uname` = "Linux" ]]; then TESTCMD="xvfb-run julia"; else TESTCMD="julia"; fi
+    - $TESTCMD --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate();import ControlSystems; cd(joinpath(dirname(pathof(ControlSystems)), "..")); include(joinpath("docs", "make.jl"))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ cache:
 
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  # Needed for plotting on travis
   - julia -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
 
 after_success:

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,7 @@
+# Set plot globals
+ENV["PLOTS_TEST"] = "true"
+ENV["GKSwstype"] = "100"
+
 using Documenter, ControlSystems, Plots, LinearAlgebra, DSP
 import GR # Bug with world age in Plots.jl, see https://github.com/JuliaPlots/Plots.jl/issues/1047
 gr()

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,3 @@
-# Set plot globals
-ENV["PLOTS_TEST"] = "true"
-ENV["GKSwstype"] = "nul"
-
 using Documenter, ControlSystems, Plots, LinearAlgebra, DSP
 import GR # Bug with world age in Plots.jl, see https://github.com/JuliaPlots/Plots.jl/issues/1047
 gr()

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
 # Set plot globals
 ENV["PLOTS_TEST"] = "true"
-ENV["GKSwstype"] = "100"
+ENV["GKSwstype"] = "nul"
 
 using Documenter, ControlSystems, Plots, LinearAlgebra, DSP
 import GR # Bug with world age in Plots.jl, see https://github.com/JuliaPlots/Plots.jl/issues/1047

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,9 +6,6 @@ import SparseArrays: sparse # In test_matrix_comps
 import DSP: conv            # In test_conversion and test_synthesis
 include("framework.jl")
 
-# Set plot globals
-ENV["GKSwstype"] = "nul"
-
 # Local definition to make sure we get warnings if we use eye
 eye_(n) = Matrix{Int64}(I, n, n)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,9 @@ import SparseArrays: sparse # In test_matrix_comps
 import DSP: conv            # In test_conversion and test_synthesis
 include("framework.jl")
 
+# Set plot globals
+ENV["GKSwstype"] = "nul"
+
 # Local definition to make sure we get warnings if we use eye
 eye_(n) = Matrix{Int64}(I, n, n)
 

--- a/test/test_plots.jl
+++ b/test/test_plots.jl
@@ -1,6 +1,6 @@
 # Set plot globals
 ENV["PLOTS_TEST"] = "true"
-ENV["GKSwstype"] = "100"
+ENV["GKSwstype"] = "nul"
 
 using Plots
 gr()

--- a/test/test_plots.jl
+++ b/test/test_plots.jl
@@ -1,3 +1,7 @@
+# Set plot globals
+ENV["PLOTS_TEST"] = "true"
+ENV["GKSwstype"] = "100"
+
 using Plots
 gr()
 default(show=false)

--- a/test/test_plots.jl
+++ b/test/test_plots.jl
@@ -1,7 +1,3 @@
-# Set plot globals
-ENV["PLOTS_TEST"] = "true"
-ENV["GKSwstype"] = "nul"
-
 using Plots
 gr()
 default(show=false)


### PR DESCRIPTION
I noticed that PkgEval does not seem happy with ControlSystems, and after checking with @mfalt he thought this might be because there is tests that require plotting which will not run on a headless server if just running `test ControlSystems`.

ControlSystems CI pipeline seems to use `xvfb` to emulate a virtual x environment to allow for some of the plot tests to run.

I found this [discourse thread](https://discourse.julialang.org/t/deactivate-plot-display-to-avoid-need-for-x-server/19359) discussing plotting on headless servers and thought I would check what the difference was using nul instad of 100 for GKSwstype.