### PR TITLE
Prevent error in complicated subplot layouts

### DIFF
--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -34,7 +34,7 @@ function getlims(xylims, plotattributes, wmag)
     end
     if !isempty(get_serieslist(plotattributes))
         subplot = get(plotattributes, :subplot, 0)
-        subplot == 0 && (return lims)
+        (subplot == 0 || (subplot isa Array)) && (return lims)
         se = seriesextrema(xylims, plotattributes, subplot)
         lims = extremareducer(lims, se)
     end


### PR DESCRIPTION
Trying to plot multiple bode plots with custom subplot layout with both gain and phase could result in an error, e.g.
```julia
bodeplot(Cpr, ω, layout=(2,2), sp=[1 3])
bodeplot!(Cpy, ω, sp=[1 3])
```