### PR TITLE
add plots to docs

### DIFF
--- a/docs/src/lib/plotting.md
+++ b/docs/src/lib/plotting.md
@@ -10,3 +10,38 @@ Pages   = ["plotting.jl"]
 Order   = [:function]
 Private = false
 ```
+
+## Examples
+`bode`
+![bode](https://github.com/JuliaControl/ControlExamplePlots.jl/blob/master/src/figures/bode.png?raw=true)
+
+`sigma`
+![sigma](https://github.com/JuliaControl/ControlExamplePlots.jl/blob/master/src/figures/sigma.png?raw=true)
+
+`margin`
+![margin](https://github.com/JuliaControl/ControlExamplePlots.jl/blob/master/src/figures/margin.png?raw=true)
+
+`gangoffour`
+![gangoffour](https://github.com/JuliaControl/ControlExamplePlots.jl/blob/master/src/figures/gangoffour.png?raw=true)
+
+`nyquist`
+![nyquist](https://github.com/JuliaControl/ControlExamplePlots.jl/blob/master/src/figures/nyquist.png?raw=true)
+
+`nichols`
+![nichols](https://github.com/JuliaControl/ControlExamplePlots.jl/blob/master/src/figures/nichols.png?raw=true)
+
+`pzmap`
+![pzmap](https://github.com/JuliaControl/ControlExamplePlots.jl/blob/master/src/figures/pzmap.png?raw=true)
+
+`rlocus`
+![rlocus](https://github.com/JuliaControl/ControlExamplePlots.jl/blob/master/src/figures/rlocus.png?raw=true)
+
+`lsim`
+![lsim](https://github.com/JuliaControl/ControlExamplePlots.jl/blob/master/src/figures/lsim.png?raw=true)
+
+`impulse`
+![impulse](https://github.com/JuliaControl/ControlExamplePlots.jl/blob/master/src/figures/impulse.png?raw=true)
+
+`step`
+![step](https://github.com/JuliaControl/ControlExamplePlots.jl/blob/master/src/figures/step.png?raw=true)
+

--- a/docs/src/man/introduction.md
+++ b/docs/src/man/introduction.md
@@ -49,7 +49,7 @@ TransferFunction{Continuous,ControlSystems.SisoRational{Float64}}
 Continuous-time transfer function model
 ```
 ## Plotting
-Plotting requires some extra care. The ControlSystems package is using `Plots.jl` ([link](https://github.com/tbreloff/Plots.jl)) as interface to generate all the plots. This means that the user is able to freely choose back-end. The plots in this manual are generated using `PyPlot`. If you have several back-ends for plotting then you can select the one you want to use with the corresponding `Plots` call (for `PyPlot` this is `Plots.pyplot()`, some alternatives are `gr(), plotly(), pgfplots()`). A simple example where we generate a plot and save it to a file is
+Plotting requires some extra care. The ControlSystems package is using `Plots.jl` ([link](https://github.com/tbreloff/Plots.jl)) as interface to generate all the plots. This means that the user is able to freely choose back-end. The plots in this manual are generated using `GR`. If you have several back-ends for plotting then you can select the one you want to use with the corresponding `Plots` call (for `GR` this is `Plots.gr()`, some alternatives are `pyplot(), plotly(), pgfplots()`). A simple example where we generate a plot and save it to a file is
 ```jldoctest; output=false
 
 fig = bodeplot(tf(1,[1,2,1]))
@@ -63,3 +63,5 @@ save_docs_plot(fig, "intro_bode.svg") # hide
 ```
 
 ![](../../plots/intro_bode.svg)
+
+More examples of plots are provided in [Plotting](@ref).


### PR DESCRIPTION
This PR adds the plots from ControlExamplePlots to the plotpage in the docs. I figured it would be cheaper to link to those plots rather than generating new plots during each build of the docs.