### PR TITLE
Removed the matrix type parameter from StateSpace, closes #413

### DIFF
--- a/docs/src/man/creating_systems.md
+++ b/docs/src/man/creating_systems.md
@@ -91,7 +91,7 @@ ControlSystems._string_mat_with_headers(a::SizedArray) = ControlSystems._string_
 Notice the different matrix types used
 ```jldoctest HSS
 julia> sys = ss([-5 0; 0 -5],[2; 2],[3 3],[0])
-StateSpace{Continuous,Int64,Array{Int64,2}}
+StateSpace{Continuous,Int64}
 A =
  -5   0
   0  -5

--- a/src/types/DelayLtiSystem.jl
+++ b/src/types/DelayLtiSystem.jl
@@ -4,7 +4,7 @@
 Represents an LTISystem with internal time-delay. See `?delay` for a convenience constructor.
 """
 struct DelayLtiSystem{T,S<:Real} <: LTISystem
-    P::PartionedStateSpace{StateSpace{Continuous,T,Matrix{T}}}
+    P::PartionedStateSpace{StateSpace{Continuous,T}}
     Tau::Vector{S} # The length of the vector tau implicitly defines the partitionging of P
 
     # function DelayLtiSystem(P::StateSpace{Continuous,T, MT}, Tau::Vector{T})
@@ -33,19 +33,19 @@ function DelayLtiSystem{T,S}(sys::StateSpace, Tau::AbstractVector{S} = Float64[]
         throw(ArgumentError("The delay vector of length $length(Tau) is too long."))
     end
 
-    psys = PartionedStateSpace{StateSpace{Continuous,T,Matrix{T}}}(sys, nu, ny)
+    psys = PartionedStateSpace{StateSpace{Continuous,T}}(sys, nu, ny)
     DelayLtiSystem{T,S}(psys, Tau)
 end
 # For converting DelayLtiSystem{T,S} to different T
-DelayLtiSystem{T}(sys::DelayLtiSystem) where {T} = DelayLtiSystem{T}(PartionedStateSpace{StateSpace{Continuous,T,Matrix{T}}}(sys.P), Float64[])
+DelayLtiSystem{T}(sys::DelayLtiSystem) where {T} = DelayLtiSystem{T}(PartionedStateSpace{StateSpace{Continuous,T}}(sys.P), Float64[])
 DelayLtiSystem{T}(sys::StateSpace) where {T} = DelayLtiSystem{T, Float64}(sys, Float64[])
 
 # From StateSpace, infer type
-DelayLtiSystem(sys::StateSpace{Continuous,T,MT}, Tau::Vector{S}) where {T, MT,S} = DelayLtiSystem{T,S}(sys, Tau)
-DelayLtiSystem(sys::StateSpace{Continuous,T,MT}) where {T, MT} = DelayLtiSystem{T,T}(sys, T[])
+DelayLtiSystem(sys::StateSpace{Continuous,T}, Tau::Vector{S}) where {T,S} = DelayLtiSystem{T,S}(sys, Tau)
+DelayLtiSystem(sys::StateSpace{Continuous,T}) where {T} = DelayLtiSystem{T,T}(sys, T[])
 
 # From TransferFunction, infer type TODO Use proper constructor instead of convert here when defined
-DelayLtiSystem(sys::TransferFunction{TE,S}) where {TE,T,S<:SisoTf{T}} = DelayLtiSystem{T}(convert(StateSpace{Continuous,T, Matrix{T}}, sys))
+DelayLtiSystem(sys::TransferFunction{TE,S}) where {TE,T,S<:SisoTf{T}} = DelayLtiSystem{T}(convert(StateSpace{Continuous,T}, sys))
 
 
 # TODO: Think through these promotions and conversions
@@ -69,7 +69,7 @@ end
 Base.convert(::Type{<:DelayLtiSystem}, sys::TransferFunction)  = DelayLtiSystem(sys)
 # Catch convertsion between T
 Base.convert(::Type{V}, sys::DelayLtiSystem)  where {T, V<:DelayLtiSystem{T}} =
-    sys isa V ? sys : V(StateSpace{Continuous,T,Matrix{T}}(sys.P.P), sys.Tau)
+    sys isa V ? sys : V(StateSpace{Continuous,T}(sys.P.P), sys.Tau)
 
 
 

--- a/src/types/DelayLtiSystem.jl
+++ b/src/types/DelayLtiSystem.jl
@@ -109,6 +109,13 @@ function /(anything, sys::DelayLtiSystem)
     /(anything, sys.P.P) # If all delays are zero, invert the inner system
 end
 
+
+# Test equality (of realizations)
+function ==(sys1::DelayLtiSystem, sys2::DelayLtiSystem)
+    all(getfield(sys1, f) == getfield(sys2, f) for f in fieldnames(DelayLtiSystem))
+end
+
+
 ninputs(sys::DelayLtiSystem) = size(sys.P.P, 2) - length(sys.Tau)
 noutputs(sys::DelayLtiSystem) = size(sys.P.P, 1) - length(sys.Tau)
 nstates(sys::DelayLtiSystem) = nstates(sys.P.P)

--- a/src/types/PartionedStateSpace.jl
+++ b/src/types/PartionedStateSpace.jl
@@ -220,3 +220,8 @@ end
 function Base.convert(::Type{<:PartionedStateSpace}, sys::T) where T<: StateSpace
     PartionedStateSpace(sys,sys.nu,sys.ny)
 end
+
+# Test equality (of realizations)
+function ==(sys1::PartionedStateSpace, sys2::PartionedStateSpace)
+    all(getfield(sys1, f) == getfield(sys2, f) for f in fieldnames(PartionedStateSpace))
+end

--- a/src/types/StateSpace.jl
+++ b/src/types/StateSpace.jl
@@ -24,28 +24,28 @@ end
 
 abstract type AbstractStateSpace{TE<:TimeEvolution} <: LTISystem end
 
-struct StateSpace{TE, T, MT<:AbstractMatrix{T}} <: AbstractStateSpace{TE}
-    A::MT
-    B::MT
-    C::MT
-    D::MT
+struct StateSpace{TE, T} <: AbstractStateSpace{TE}
+    A::Matrix{T}
+    B::Matrix{T}
+    C::Matrix{T}
+    D::Matrix{T}
     timeevol::TE
-    function StateSpace{TE, T, MT}(A::MT, B::MT, C::MT, D::MT, timeevol::TE) where {TE<:TimeEvolution, T, MT <: AbstractMatrix{T}}
+    function StateSpace{TE, T}(A::Matrix{T}, B::Matrix{T}, C::Matrix{T}, D::Matrix{T}, timeevol::TE) where {TE<:TimeEvolution, T}
         state_space_validation(A,B,C,D)
-        new{TE, T, MT}(A, B, C, D, timeevol)
+        new{TE, T}(A, B, C, D, timeevol)
     end
-    function StateSpace(A::MT, B::MT, C::MT, D::MT, timeevol::TE) where {TE<:TimeEvolution, T, MT <: AbstractMatrix{T}}
+    function StateSpace(A::Matrix{T}, B::Matrix{T}, C::Matrix{T}, D::Matrix{T}, timeevol::TE) where {TE<:TimeEvolution, T}
         state_space_validation(A,B,C,D)
-        new{TE, T, MT}(A, B, C, D, timeevol)
+        new{TE, T}(A, B, C, D, timeevol)
     end
 end
 # Constructor for Discrete system
-function StateSpace(A::MT, B::MT, C::MT, D::MT, Ts::Number) where {T, MT <: AbstractMatrix{T}}
+function StateSpace(A::Matrix{T}, B::Matrix{T}, C::Matrix{T}, D::Matrix{T}, Ts::Number) where {T}
     state_space_validation(A,B,C,D)
     StateSpace(A, B, C, D, Discrete(Ts))
 end
 # Constructor for Continuous system
-function StateSpace(A::MT, B::MT, C::MT, D::MT) where {T, MT <: AbstractMatrix{T}}
+function StateSpace(A::Matrix{T}, B::Matrix{T}, C::Matrix{T}, D::Matrix{T}) where {T}
     state_space_validation(A,B,C,D)
     StateSpace(A, B, C, D, Continuous())
 end
@@ -72,19 +72,19 @@ end
 const AbstractNumOrArray = Union{Number, AbstractVecOrMat}
 
 # Explicit construction with different types
-function StateSpace{TE,T,MT}(A::AbstractNumOrArray, B::AbstractNumOrArray, C::AbstractNumOrArray, D::AbstractNumOrArray, timeevol::TimeEvolution) where {TE, T, MT <: AbstractMatrix{T}}
+function StateSpace{TE,T}(A::AbstractNumOrArray, B::AbstractNumOrArray, C::AbstractNumOrArray, D::AbstractNumOrArray, timeevol::TimeEvolution) where {TE, T}
     D = fix_D_matrix(T, B, C, D)
-    return StateSpace{TE, T,Matrix{T}}(MT(to_matrix(T, A)), MT(to_matrix(T, B)), MT(to_matrix(T, C)), MT(D), TE(timeevol))
+    return StateSpace{TE, T}(to_matrix(T, A), to_matrix(T, B), to_matrix(T, C), to_matrix(T, D), TE(timeevol))
 end
 
 # Explicit conversion
-function StateSpace{TE,T,MT}(sys::StateSpace) where {TE, T, MT <: AbstractMatrix{T}}
-    StateSpace{TE,T,MT}(sys.A,sys.B,sys.C,sys.D,sys.timeevol)
+function StateSpace{TE,T}(sys::StateSpace) where {TE, T}
+    StateSpace{TE,T}(sys.A,sys.B,sys.C,sys.D,sys.timeevol)
 end
 
 function StateSpace(A::AbstractNumOrArray, B::AbstractNumOrArray, C::AbstractNumOrArray, D::AbstractNumOrArray, timeevol::TimeEvolution)
     A, B, C, D, T = to_similar_matrices(A,B,C,D)
-    return StateSpace{typeof(timeevol),T,Matrix{T}}(A, B, C, D, timeevol)
+    return StateSpace{typeof(timeevol),T}(A, B, C, D, timeevol)
 end
 # General Discrete constructor
 StateSpace(A::AbstractNumOrArray, B::AbstractNumOrArray, C::AbstractNumOrArray, D::AbstractNumOrArray, Ts::Number) =
@@ -115,13 +115,13 @@ StateSpace(sys::LTISystem) = convert(StateSpace, sys)
 """
     `sys = ss(A, B, C, D [,Ts])`
 
-Create a state-space model `sys::StateSpace{TE, T, MT<:AbstractMatrix{T}}`
-where `MT` is the type of matrixes `A,B,C,D`, `T` the element type and TE is Continuous or Discrete.
+Create a state-space model `sys::StateSpace{TE, T}`
+with matrix element type `T` and TE is `Continuous` or `<:Discrete`.
 
 This is a continuous-time model if `Ts` is omitted.
-Otherwise, this is a discrete-time model with sampling period Ts.
+Otherwise, this is a discrete-time model with sampling period `Ts`.
 
-`sys = ss(D [, Ts])` specifies a static gain matrix D.
+`sys = ss(D [, Ts])` specifies a static gain matrix `D`.
 """
 ss(args...;kwargs...) = StateSpace(args...;kwargs...)
 
@@ -214,7 +214,7 @@ function isapprox(sys1::ST1, sys2::ST2; kwargs...) where {ST1<:AbstractStateSpac
 end
 
 ## ADDITION ##
-function +(s1::StateSpace{TE,T,MT}, s2::StateSpace{TE,T,MT}) where {TE,T, MT}
+function +(s1::StateSpace{TE,T}, s2::StateSpace{TE,T}) where {TE,T}
     #Ensure systems have same dimensions
     if size(s1) != size(s2)
         error("Systems have different shapes.")
@@ -227,7 +227,7 @@ function +(s1::StateSpace{TE,T,MT}, s2::StateSpace{TE,T,MT}) where {TE,T, MT}
     C = [s1.C s2.C;]
     D = [s1.D + s2.D;]
 
-    return StateSpace{TE,T,MT}(A, B, C, D, timeevol)
+    return StateSpace{TE,T}(A, B, C, D, timeevol)
 end
 
 function +(s1::HeteroStateSpace, s2::HeteroStateSpace)
@@ -258,7 +258,7 @@ end
 -(sys::ST) where ST <: AbstractStateSpace = ST(sys.A, sys.B, -sys.C, -sys.D, sys.timeevol)
 
 ## MULTIPLICATION ##
-function *(sys1::StateSpace{TE,T,MT}, sys2::StateSpace{TE,T,MT}) where {TE,T, MT}
+function *(sys1::StateSpace{TE,T}, sys2::StateSpace{TE,T}) where {TE,T}
     #Check dimension alignment
     #Note: sys1*sys2 = y <- sys1 <- sys2 <- u
     if sys1.nu != sys2.ny
@@ -271,7 +271,7 @@ function *(sys1::StateSpace{TE,T,MT}, sys2::StateSpace{TE,T,MT}) where {TE,T, MT
     B = [sys1.B*sys2.D ; sys2.B]
     C = [sys1.C   sys1.D*sys2.C;]
     D = [sys1.D*sys2.D;]
-    return StateSpace{TE,T,MT}(A, B, C, D, timeevol)
+    return StateSpace{TE,T}(A, B, C, D, timeevol)
 end
 
 function *(sys1::HeteroStateSpace, sys2::HeteroStateSpace)

--- a/src/types/conversion.jl
+++ b/src/types/conversion.jl
@@ -19,37 +19,34 @@
 # Base.convert(::Type{<:TransferFunction{<:SisoRational}}, b::Number) = tf(b)
 # Base.convert(::Type{<:TransferFunction{<:SisoZpk}}, b::Number) = zpk(b)
 #
-Base.convert(::Type{TransferFunction{TE,SisoZpk{T1, TR1}}}, b::AbstractMatrix{T2}) where {TE, T1, TR1, T2<:Number} =
-    zpk(T1.(b), undef_sampletime(TE))
-Base.convert(::Type{TransferFunction{TE,SisoRational{T1}}}, b::AbstractMatrix{T2}) where {TE, T1, T2<:Number} =
-    tf(T1.(b), undef_sampletime(TE))
+Base.convert(::Type{TransferFunction{TE,SisoZpk{T1, TR1}}}, D::AbstractMatrix{T2}) where {TE, T1, TR1, T2<:Number} =
+    zpk(convert(Matrix{T1}, D), undef_sampletime(TE))
+Base.convert(::Type{TransferFunction{TE,SisoRational{T1}}}, D::AbstractMatrix{T2}) where {TE, T1, T2<:Number} =
+    tf(Matrix{T1}(D), undef_sampletime(TE))
 
-function convert(::Type{StateSpace{TE,T,MT}}, D::AbstractMatrix{<:Number}) where {TE,T, MT}
+function convert(::Type{StateSpace{TE,T}}, D::AbstractMatrix{<:Number}) where {TE,T}
     (ny, nu) = size(D)
-    A = MT(fill(zero(T), (0,0)))
-    B = MT(fill(zero(T), (0,nu)))
-    C = MT(fill(zero(T), (ny,0)))
-    D = convert(MT, D)
-    return StateSpace{TE,T,MT}(A,B,C,D,undef_sampletime(TE))
+    A = fill(zero(T), (0,0))
+    B = fill(zero(T), (0,nu))
+    C = fill(zero(T), (ny,0))
+    D = convert(Matrix{T}, D)
+    return StateSpace{TE,T}(A,B,C,D,undef_sampletime(TE))
 end
 
 # TODO We still dont have TransferFunction{..}(number/array) constructors
-Base.convert(::Type{TransferFunction{TE,SisoRational{T}}}, b::Number) where {TE, T} =
-    tf(T(b), undef_sampletime(TE))
-Base.convert(::Type{TransferFunction{TE,SisoZpk{T,TR}}}, b::Number) where {TE, T, TR} =
-    zpk(T(b), undef_sampletime(TE))
-Base.convert(::Type{StateSpace{TE,T,MT}}, b::Number) where {TE, T, MT} =
-    convert(StateSpace{TE,T,MT}, fill(b, (1,1)))
+Base.convert(::Type{TransferFunction{TE,SisoRational{T}}}, d::Number) where {TE, T} =
+    tf(T(d), undef_sampletime(TE))
+
+Base.convert(::Type{TransferFunction{TE,SisoZpk{T,TR}}}, d::Number) where {TE, T, TR} =
+    zpk(T(d), undef_sampletime(TE))
+
+Base.convert(::Type{StateSpace{TE,T}}, d::Number) where {TE, T} =
+    convert(StateSpace{TE,T}, fill(d, (1,1)))
 #
 # Base.convert(::Type{TransferFunction{Continuous,<:SisoRational{T}}}, b::Number) where {T} = tf(T(b), Continuous())
 # Base.convert(::Type{TransferFunction{Continuous,<:SisoZpk{T, TR}}}, b::Number) where {T, TR} = zpk(T(b), Continuous())
 # Base.convert(::Type{StateSpace{Continuous,T, MT}}, b::Number) where {T, MT} = convert(StateSpace{Continuous,T, MT}, fill(b, (1,1)))
 
-#
-# Base.convert(::Type{<:TransferFunction{<:SisoZpk}}, s::TransferFunction) = zpk(s)
-# Base.convert(::Type{<:TransferFunction{<:SisoRational}}, s::TransferFunction) = tf(s)
-
-#
 # function Base.convert{T<:Real,S<:TransferFunction}(::Type{S}, b::VecOrMat{T})
 #     r = Matrix{S}(size(b,2),1)
 #     for j=1:size(b,2)
@@ -64,16 +61,16 @@ function convert(::Type{TransferFunction{TE,S}}, G::TransferFunction) where {TE,
     return TransferFunction{TE,eltype(Gnew_matrix)}(Gnew_matrix, TE(G.timeevol))
 end
 
-function convert(::Type{S}, sys::AbstractStateSpace) where {T, MT, TE, S <:StateSpace{TE,T,MT}}
-    if sys isa S
+function convert(::Type{StateSpace{TE,T}}, sys::AbstractStateSpace) where {TE, T}
+    if sys isa StateSpace{TE, T}
         return sys
     else
-        return StateSpace{TE, T,MT}(convert(MT, sys.A), convert(MT, sys.B), convert(MT, sys.C), convert(MT, sys.D), TE(sys.timeevol))
+        return StateSpace{TE, T}(convert(Matrix{T}, sys.A), convert(Matrix{T}, sys.B), convert(Matrix{T}, sys.C), convert(Matrix{T}, sys.D), TE(sys.timeevol))
     end
 end
 
 # TODO Maybe add convert on matrices
-Base.convert(::Type{HeteroStateSpace{TE1,AT,BT,CT,DT}}, s::StateSpace{TE2,T,MT}) where {TE1,TE2,T,MT,AT,BT,CT,DT} =
+Base.convert(::Type{HeteroStateSpace{TE1,AT,BT,CT,DT}}, s::StateSpace{TE2,T}) where {TE1,TE2,T,AT,BT,CT,DT} =
     HeteroStateSpace{TE1,AT,BT,CT,DT}(s.A,s.B,s.C,s.D,TE1(s.timeevol))
 
 Base.convert(::Type{HeteroStateSpace}, s::StateSpace) = HeteroStateSpace(s)
@@ -84,11 +81,11 @@ Base.convert(::Type{StateSpace}, s::HeteroStateSpace{Continuous}) = StateSpace(s
 function Base.convert(::Type{StateSpace}, G::TransferFunction{TE,<:SisoTf{T0}}) where {TE,T0<:Number}
 
     T = Base.promote_op(/,T0,T0)
-    convert(StateSpace{TE,T,Matrix{T}}, G)
+    convert(StateSpace{TE,T}, G)
 end
 
 
-function Base.convert(::Type{StateSpace{TE,T,MT}}, G::TransferFunction) where {TE,T<:Number, MT<:AbstractArray{T}}
+function Base.convert(::Type{StateSpace{TE,T}}, G::TransferFunction) where {TE,T<:Number}
     if !isproper(G)
         error("System is improper, a state-space representation is impossible")
     end
@@ -97,7 +94,7 @@ function Base.convert(::Type{StateSpace{TE,T,MT}}, G::TransferFunction) where {T
     # could be much cleaner.
     #T = Base.promote_op(/, T0, T0)
 
-    Ac = Bc = Cc = Dc = A = B = C = D = Array{T}(undef, 0, 0)
+    Ac = Bc = Cc = Dc = A = B = C = D = Matrix{T}(undef, 0, 0)
     for i=1:ninputs(G)
         for j=1:noutputs(G)
             a, b, c, d = siso_tf_to_ss(T, G.matrix[j, i])
@@ -122,7 +119,7 @@ function Base.convert(::Type{StateSpace{TE,T,MT}}, G::TransferFunction) where {T
         end
     end
     # A, B, C = balance_statespace(A, B, C)[1:3] NOTE: Use balance?
-    return StateSpace{TE,T,MT}(A, B, C, D, TE(G.timeevol))
+    return StateSpace{TE,T}(A, B, C, D, TE(G.timeevol))
 end
 
 siso_tf_to_ss(T::Type, f::SisoTf) = siso_tf_to_ss(T, convert(SisoRational, f))
@@ -131,8 +128,8 @@ siso_tf_to_ss(T::Type, f::SisoTf) = siso_tf_to_ss(T, convert(SisoRational, f))
 function siso_tf_to_ss(T::Type, f::SisoRational)
 
     num0, den0 = numvec(f), denvec(f)
-    # Normalize the numerator and denominator,
-    # To allow realization of transfer functions that are proper, but now strictly proper
+    # Normalize the numerator and denominator to allow realization of transfer functions
+    # that are proper, but not strictly proper
     num = num0 / den0[1]
     den = den0 / den0[1]
 
@@ -141,22 +138,22 @@ function siso_tf_to_ss(T::Type, f::SisoRational)
     # Get numerator coefficient of the same order as the denominator
     bN = length(num) == N+1 ? num[1] : 0
 
-    if N==0 #|| num == zero(Polynomial{T})
-        A = fill(zero(T), 0, 0)
-        B = fill(zero(T), 0, 1)
-        C = fill(zero(T), 1, 0)
+    if N == 0 #|| num == zero(Polynomial{T})
+        A = zeros(T, (0, 0))
+        B = zeros(T, (0, 1))
+        C = zeros(T, (1, 0))
     else
-        A = diagm(1 => fill(one(T), N-1))
+        A = diagm(1 => ones(T, N-1))
         A[end, :] .= -reverse(den)[1:end-1]
 
-        B = fill(zero(T), N, 1)
+        B = zeros(T, (N, 1))
         B[end] = one(T)
 
-        C = fill(zero(T), 1, N)
+        C = zeros(T, (1, N))
         C[1:min(N, length(num))] = reverse(num)[1:min(N, length(num))]
         C[:] -= bN * reverse(den)[1:end-1] # Can index into polynomials at greater inddices than their length
     end
-    D = fill(bN, 1, 1)
+    D = fill(bN, (1, 1))
 
     return A, B, C, D
 end

--- a/src/types/promotion.jl
+++ b/src/types/promotion.jl
@@ -1,11 +1,3 @@
-# Base.eltype{T}(::Type{Polynomial{T}}) = T
-# Base.eltype{T}(::Type{TransferFunction{T}}) = T
-# Base.eltype{T}(::Type{SisoZpk{T}}) = T
-# Base.eltype{T}(::Type{SisoRational{T}}) = T
-# Base.eltype{T}(::Type{StateSpace{T}}) = T
-#
-
-
 # """
 #     responsetype(T)
 # Return the numerical type of the time-response for composite LTISystem type `T`, e.g., `responsetype(ss(1.)) == Float64`
@@ -17,46 +9,29 @@
 # responsetype{T}(::Type{T}) = T # Catch all
 
 
-#matrix_type{T}(::Type{StateSpace{T, M{T}}}) = T
-
 # Abstract type pyramid =============================================================
 
 # NOTE: a lot that doesnt seem to be used...
 #Base.promote_rule(::Type{StateSpace{T1}}, ::Type{StateSpace{T2}}) where {T1,T2} = StateSpace{promote_type(T1, T2)}
 
 # NOTE: Is the below thing correct always?
-function Base.promote_rule(::Type{StateSpace{TE1,T1,MT1}}, ::Type{StateSpace{TE2,T2,MT2}}) where {TE1,TE2,T1,T2,MT1,MT2}
-    MT = promote_type(MT1, MT2)
-    TE = promote_type(TE1, TE2)
-    if isconcretetype(MT) # This sometimes fails and produces a Unionall. This condition can be checked at compile time, checked by f(x,y) = (MT = promote_type(x, y); isconcretetype(MT)); @code_llvm f(Int,Float64)
-        StateSpace{TE,promote_type(T1, T2),MT}
-    else # If fail, fall back to an ordinary matrix
-        FT = promote_type(T1, T2)
-        StateSpace{TE,FT,Matrix{FT}}
-    end
-end
+Base.promote_rule(::Type{StateSpace{TE1,T1}}, ::Type{StateSpace{TE2,T2}}) where {TE1,TE2,T1,T2} =
+    StateSpace{promote_type(TE1,TE2), promote_type(T1,T2)}
 
-Base.promote_rule(::Type{StateSpace{TE1,T,MT}}, ::Type{HeteroStateSpace{TE2,AT,BT,CT,DT}}) where {TE1,TE2,T,MT,AT,BT,CT,DT} =
-    HeteroStateSpace{promote_type(TE1, TE2),promote_type(MT,AT),promote_type(MT,BT),promote_type(MT,CT),promote_type(MT,DT)}
+Base.promote_rule(::Type{StateSpace{TE1,T}}, ::Type{HeteroStateSpace{TE2,AT,BT,CT,DT}}) where {TE1,TE2,T,AT,BT,CT,DT} =
+    HeteroStateSpace{promote_type(TE1, TE2),promote_type(Matrix{T},AT),promote_type(Matrix{T},BT),promote_type(Matrix{T},CT),promote_type(Matrix{T},DT)}
 
-function Base.promote_rule(::Type{TransferFunction{TE1,S1}}, ::Type{StateSpace{TE2,T2,MT}}) where {TE1,TE2,T1,S1<:SisoTf{T1},T2,MT}
-    #promote_type(Base.promote_op(/, T1, T1), T2)
-    StateSpace{promote_type(TE1, TE2), promote_type(T1,T2), promote_type(Matrix{T1},MT)}
-end
-# NOTE: Perhaps should try to keep matrix structure?
+Base.promote_rule(::Type{TransferFunction{TE1,S1}}, ::Type{StateSpace{TE2,T2}}) where {TE1,TE2,T1,S1<:SisoTf{T1},T2} =
+    StateSpace{promote_type(TE1, TE2), promote_type(T1,T2)}
 
-function Base.promote_rule(::Type{TransferFunction{TE1,S1}}, ::Type{DelayLtiSystem{T2}}) where {TE1,T1,S1<:SisoTf{T1},T2}
+Base.promote_rule(::Type{TransferFunction{TE1,S1}}, ::Type{DelayLtiSystem{T2}}) where {TE1,T1,S1<:SisoTf{T1},T2} =
     DelayLtiSystem{promote_type(T1,T2)}
-end
-function Base.promote_rule(::Type{StateSpace{TE1,T1,MT}}, ::Type{DelayLtiSystem{T2}}) where {TE1,T1,MT,T2}
+
+Base.promote_rule(::Type{StateSpace{TE1,T1}}, ::Type{DelayLtiSystem{T2}}) where {TE1,T1,T2} =
     DelayLtiSystem{promote_type(T1,T2)}
-end
 
 Base.promote_rule(::Type{TransferFunction{TE1,S1}}, ::Type{TransferFunction{TE2,S2}}) where {TE1, TE2, S1, S2} =
     TransferFunction{promote_type(TE1,TE2),promote_type(S1, S2)}
-#Base.promote_rule(::Type{SisoTf}, ::Type{TransferFunction}) = TransferFunction
-#Base.promote_rule(::Type{SisoZpk}, ::Type{TransferFunction}) = TransferFunction
-#Base.promote_rule(::Type{SisoRational}, ::Type{TransferFunction}) = TransferFunction
 
 
 #function Base.promote_rule{T<:StateSpace,P<:TransferFunction}(::Type{T}, ::Type{P})  #where T <: StateSpace where P <: TransferFunction
@@ -67,87 +42,30 @@ Base.promote_rule(::Type{TransferFunction{TE1,S1}}, ::Type{TransferFunction{TE2,
 
 # Promotion of Number ==========================================================
 
-#Base.promote_rule{T1<:Number,T2<:Number}(::Type{TransferFunction{S}}, ::T2) = promote_type(T1, T2)
-
 Base.promote_rule(::Type{TransferFunction{TE,S}}, ::Type{T2}) where {TE, S<:SisoTf, T2<:Number} =
     TransferFunction{TE,promote_type(S, T2)}
 
 # TODO Figure out a better way
-function Base.promote_rule(::Type{StateSpace{TE, T1, MT}}, ::Type{T2}) where {TE, T1, MT, T2<:Number}
-    NewMT = Base.promote_op(*, MT, T2)
-    StateSpace{TE, eltype(NewMT), NewMT}
+function Base.promote_rule(::Type{StateSpace{TE, T1}}, ::Type{T2}) where {TE, T1, T2<:Number}
+    StateSpace{TE, promote_type(T1, T2)}
 end
-
-Base.promote_rule(::Type{TransferFunction{TE, SisoZpk{T1,TR1}}}, ::Type{M2}) where {TE, T1, TR1, T2, M2<:AbstractMatrix{T2}} =
-    TransferFunction{TE, SisoZpk{T1, promote_type(TR1, T2)}}
-
-Base.promote_rule(::Type{TransferFunction{TE, SisoRational{T1}}}, ::Type{M2}) where {TE, T1, T2, M2<:AbstractMatrix{T2}} =
-    TransferFunction{TE, SisoRational{promote_type(T1, T2)}}
-
-function Base.promote_rule(::Type{StateSpace{TE, T1, MT1}}, ::Type{MT2}) where {TE, T1, MT1, MT2<:AbstractMatrix}
-    MT = promote_type(MT1, MT2)
-    StateSpace{TE, eltype(MT), MT}
-end
-
-Base.promote_rule(::Type{DelayLtiSystem{T1,S}}, ::Type{MT1}) where {T1, S, MT1<:AbstractMatrix} =
-    DelayLtiSystem{promote_type(T1, eltype(MT1)),S}
-
-#Base.promote_rule{S<:TransferFunction{<:SisoTf}}(::Type{S}, ::Type{<:Real}) = S
-
-# We want this, but not possible, so hardcode for SisoTypes
-#Base.promote_rule(::Type{S}, ::Type{T2}) where {T1, S<:SisoTf{T1}, T2<:Number} = S{promote_type(T1, T2)}
 
 function Base.promote_rule(::Type{SisoZpk{T1,C2}}, ::Type{T2}) where {T1, C2, T2<:Number}
     GainType = promote_type(T1, T2)
     return SisoZpk{GainType, complex(GainType)}
 end
 Base.promote_rule(::Type{SisoRational{T1}}, ::Type{T2}) where {T1, T2<:Number} = SisoRational{promote_type(T1,T2)}
-#Base.promote_rule(::Type{StateSpace{T1, MT}}, ::Type{T2}) where {T1, T2<:Number} = SisoRational{promote_type(T1,T2)}
 
-#Base.promote_rule{T<:SisoZpk}(::Type{T}, ::Type{<:Real}) = T
-#Base.promote_rule{T}(::Type{SisoRational{T}}, ::Type{<:Real}) = SisoRational{T}
-#Base.promote_rule{T}(::Type{StateSpace{T}}, ::Type{<:Real}) = StateSpace{T}
-#Base.promote_rule{S<:TransferFunction{<:SisoTf},T<:Real}(::Type{S}, ::Union{Type{Array{T,2}},Type{Array{T,1}}}) = S
+# Promotion of Matrix ==========================================================
 
+Base.promote_rule(::Type{TransferFunction{TE, SisoZpk{T1,TR1}}}, ::Type{MT}) where {TE, T1, TR1, T2, MT<:AbstractMatrix{T2}} =
+    TransferFunction{TE, SisoZpk{T1, promote_type(TR1, T2)}}
 
-# Less abstract promotions
-#Base.promote_rule(::Type{TransferFunction{SisoRational}}, ::Type{TransferFunction{SisoZpk}}) = TransferFunction{SisoZpk} # NOTE: Is this what we want?
+Base.promote_rule(::Type{TransferFunction{TE, SisoRational{T1}}}, ::Type{MT}) where {TE, T1, T2, MT<:AbstractMatrix{T2}} =
+    TransferFunction{TE, SisoRational{promote_type(T1, T2)}}
 
+Base.promote_rule(::Type{StateSpace{TE, T1}}, ::Type{MT}) where {TE, T1, MT<:AbstractMatrix} =
+    StateSpace{TE, promote_type(T,eltype(MT))}
 
-
-
-# function Base.promote_rule{T1c<:SisoZpk,T2c<:SisoRational}(::Type{T1c}, ::Type{T2c})
-#     upper_type = SisoZpk
-#     inner_type = promote_type(arraytype(T1c), arraytype(T2c))
-#     upper_type{inner_type}
-# end
-
-
-
-# @show siso_type = promote_type(eltype.(systems)...)
-# if isleaftype(siso_type)
-#     siso_type = siso_type.name.wrapper
-# end
-# # array_type = promote_type(arraytype.(systems)...)
-# # mat = hcat([(e->convert(siso_type{array_type}, e)).(s.matrix) for s in systems]...)
-# @show promote_type([s.matrix for s in systems]...)
-
-
-
-
-#
-
-#
-#
-# # Promote_op types # NOTE: Needed?
-# Base.promote_op{T<:SisoTf}(::Any, ::Type{T}, ::Type{T}) = T
-#
-# #Just default SisoTf to SisoRational
-# SisoTf(args...) = SisoRational(args...)
-#
-# Base.zero(::Type{<:SisoTf}) = zero(SisoRational)
-# Base.zero(::SisoTf) = zero(SisoRational)
-# Base.zero(::Type{<:SisoZpk}) = SisoZpk(Float64[],Float64[],0.0)
-# Base.zero(::SisoZpk) = Base.zero(SisoZpk)
-# Base.zero{T}(::Type{SisoRational{T}}) = SisoRational(zero(Polynomial{T}), one(Polynomial{T})) # FIXME: Is the in analogy with how zero for SisoRational is createdzer?
-# Base.zero{T}(::SisoRational{T}) = Base.zero(SisoRational{T})
+Base.promote_rule(::Type{DelayLtiSystem{T1,S}}, ::Type{MT}) where {T1, S, MT<:AbstractMatrix} =
+    DelayLtiSystem{promote_type(T1, eltype(MT)),S}

--- a/test/test_connections.jl
+++ b/test/test_connections.jl
@@ -155,12 +155,12 @@ arr4[1] = ss(0); arr4[2] = ss(1); arr4[3] = ss(2)
 @test [D_111 1.0] == ss([1.0], [2.0 0.0], [3.0], [4.0 1.0], 0.005)
 @test [1.0 D_111] == ss([1.0], [0.0 2.0], [3.0], [1.0 4.0], 0.005)
 # Type and sample time
-@test [D_111 1.0] isa StateSpace{Discrete{Float64},Float64,Array{Float64,2}}
+@test [D_111 1.0] isa StateSpace{Discrete{Float64},Float64}
 @test [D_111 1.0].Ts == 0.005
 # Continuous version
 @test [C_111 1.0] == ss([1.0], [2.0 0.0], [3.0], [4.0 1.0])
 @test [1.0 C_111] == ss([1.0], [0.0 2.0], [3.0], [1.0 4.0])
-@test [C_111 1.0] isa StateSpace{Continuous,Float64,Array{Float64,2}}
+@test [C_111 1.0] isa StateSpace{Continuous,Float64}
 @test [C_111 1.0].Ts == 0.0
 @test_logs (:warn,
             "Getting time 0.0 for non-discrete systems is deprecated. Check `isdiscrete` before trying to access time."

--- a/test/test_connections.jl
+++ b/test/test_connections.jl
@@ -91,6 +91,9 @@ s = tf("s")
 @test [D_111; Dtf_212] == [D_111; ss(Dtf_212)]
 @test append(D_111, Dtf_211) == append(D_111, ss(Dtf_211))
 
+# Combination of DelayLtiSystem with TransferFunction and StateSpace
+@test [delay(1.0) tf(1, [1,2])] == [delay(1.0) ss(-2.0,1,1,0)]
+@test [delay(1.0) zpk([], [-2], 1)] == [delay(1.0) ss(-2.0,1,1,0)]
 
 # hcat and vcat for StateSpace and Matrix
 A = [-1.1 -1.2; -1.3 -1.4]

--- a/test/test_conversion.jl
+++ b/test/test_conversion.jl
@@ -108,7 +108,7 @@ G3 = tf([1,1],[1,0,-1])
 
 
 ## Test some BigFloat
-SSBigFloat = StateSpace{Continuous,BigFloat,Array{BigFloat,2}}
+SSBigFloat = StateSpace{Continuous,BigFloat}
 ZpkBigFloat = TransferFunction{Continuous,ControlSystems.SisoZpk{BigFloat,Complex{BigFloat}}}
 RationalBigFloat = TransferFunction{Continuous,ControlSystems.SisoRational{BigFloat}}
 
@@ -132,8 +132,8 @@ fb = BigFloat(1.0)*f
 b = 1.5
 D22 = [1.0 2.0; 3.0 4.0]
 
-@test convert(StateSpace{Continuous,Float64,Matrix{Float64}}, D22) == ss(D22)
-@test convert(StateSpace{Continuous,Float64,Matrix{Float64}}, b) == ss(b)
+@test convert(StateSpace{Continuous,Float64}, D22) == ss(D22)
+@test convert(StateSpace{Continuous,Float64}, b) == ss(b)
 
 @test convert(TransferFunction{Continuous,ControlSystems.SisoRational{Float64}}, D22) == tf(D22)
 @test convert(TransferFunction{Continuous,ControlSystems.SisoRational{Float64}}, b) == tf(b)

--- a/test/test_delayed_systems.jl
+++ b/test/test_delayed_systems.jl
@@ -9,9 +9,9 @@ using DelayDiffEq
 @test typeof(promote(delay(0.2), ss(1.0 + im))[1]) == DelayLtiSystem{Complex{Float64}, Float64}
 
 if VERSION >= v"1.6.0-DEV.0"
-    @test sprint(show, ss(1,1,1,1)*delay(1.0)) == "DelayLtiSystem{Float64, Float64}\n\nP: StateSpace{Continuous, Float64, Matrix{Float64}}\nA = \n 1.0\nB = \n 0.0  1.0\nC = \n 1.0\n 0.0\nD = \n 0.0  1.0\n 1.0  0.0\n\nContinuous-time state-space model\n\nDelays: [1.0]\n"
+    @test sprint(show, ss(1,1,1,1)*delay(1.0)) == "DelayLtiSystem{Float64, Float64}\n\nP: StateSpace{Continuous, Float64}\nA = \n 1.0\nB = \n 0.0  1.0\nC = \n 1.0\n 0.0\nD = \n 0.0  1.0\n 1.0  0.0\n\nContinuous-time state-space model\n\nDelays: [1.0]\n"
 else
-    @test sprint(show, ss(1,1,1,1)*delay(1.0)) == "DelayLtiSystem{Float64,Float64}\n\nP: StateSpace{Continuous,Float64,Array{Float64,2}}\nA = \n 1.0\nB = \n 0.0  1.0\nC = \n 1.0\n 0.0\nD = \n 0.0  1.0\n 1.0  0.0\n\nContinuous-time state-space model\n\nDelays: [1.0]\n"
+    @test sprint(show, ss(1,1,1,1)*delay(1.0)) == "DelayLtiSystem{Float64,Float64}\n\nP: StateSpace{Continuous,Float64}\nA = \n 1.0\nB = \n 0.0  1.0\nC = \n 1.0\n 0.0\nD = \n 0.0  1.0\n 1.0  0.0\n\nContinuous-time state-space model\n\nDelays: [1.0]\n"
 end
 
 # Extremely baseic tests

--- a/test/test_delayed_systems.jl
+++ b/test/test_delayed_systems.jl
@@ -1,6 +1,8 @@
 using DelayDiffEq
 
 @testset "test_delay_system" begin
+
+# For simplicity, equality of DelayLtiSystems are tested over a finite set of frequencies
 ω = 0.0:8
 
 
@@ -49,6 +51,10 @@ P2_fr = (im*ω .+ 1) ./ (im*ω .+ 2)
 @test freqresp(P2 * delay(1), ω)[:] ≈ P2_fr .* exp.(-im*ω) rtol=1e-15
 @test freqresp(delay(1) * P2, ω)[:] ≈ P2_fr .* exp.(-im*ω) rtol=1e-15
 
+
+# Equality
+@test P1 == deepcopy(P1)
+@test P1 != deepcopy(P2)
 
 # evalfr
 s_vec = [0, 1im, 1, 1 + 1im]

--- a/test/test_partitioned_statespace.jl
+++ b/test/test_partitioned_statespace.jl
@@ -21,7 +21,6 @@ sys1.D12 == matrix(6.0)
 sys1.D21 == matrix(8.0)
 sys1.D22 == matrix(9.0)
 
-
 ##
 sys2 = ControlSystems.PartionedStateSpace(ss(fill(1.0, 2, 2), fill(2.0, 2, 5), fill(3.0, 7, 2), fill(4.0, 7, 5)), 2, 3)
 
@@ -35,6 +34,10 @@ sys2 = ControlSystems.PartionedStateSpace(ss(fill(1.0, 2, 2), fill(2.0, 2, 5), f
 @test sys2.D21 == fill(4.0, 4, 2)
 @test sys2.D22 == fill(4.0, 4, 3)
 
+
+
+@test sys1 == deepcopy(sys1)
+@test sys1 != deepcopy(sys2)
 
 # TODO: Add some tests for interconnections, implicitly tested through delay system implementations though
 @test (sys1 + sys1).P[1, 1] == (sys1.P[1,1] + sys1.P[1,1])

--- a/test/test_promotion.jl
+++ b/test/test_promotion.jl
@@ -35,6 +35,9 @@ TG2 = typeof(G2)
 @test promote_type(typeof(tf(1)), typeof(tf(1))) == typeof(tf(1))
 @test promote_type(typeof(ss(1)), typeof(ss(1))) == typeof(ss(1))
 
+
+@test promote(ss(1), 1.0) == (ss(1.), ss(1.))
+@test promote(ss(1), 1) == (ss(1.), ss(1.))
 @test promote(ss(1), ss(1.)) == (ss(1.), ss(1.))
 @test promote(ss(1), tf(1.)) == (ss(1.), ss(1.))
 @test promote(ss(1), zpk(1.)) == (ss(1.), ss(1.))
@@ -43,5 +46,7 @@ TG2 = typeof(G2)
 @test promote(zpk(1), tf(1)) == (zpk(1.), zpk(1.))
 @test promote(ss(1), ss([1 .*im])) == (ss([1+0*im]),ss([1 .*im]))
 @test promote(ss(1), tf([1 .*im])) == (ss([1+0*im]),ss([1 .*im]))
+@test promote(tf(1), 1) == (tf(1.), tf(1.))
+
 
 end

--- a/test/test_statespace.jl
+++ b/test/test_statespace.jl
@@ -112,18 +112,18 @@
         # Printing
         if SS <: StateSpace
             if VERSION >= v"1.6.0-DEV.0"
-                @test sprint(show, C_222) == "StateSpace{Continuous, Int64, Matrix{Int64}}\nA = \n -5  -3\n  2  -9\nB = \n 1  0\n 0  2\nC = \n 1  0\n 0  1\nD = \n 0  0\n 0  0\n\nContinuous-time state-space model"
-                @test sprint(show, C_022) == "StateSpace{Continuous, Float64, Matrix{Float64}}\nD = \n 4.0  0.0\n 0.0  4.0\n\nContinuous-time state-space model"
-                @test sprint(show, D_022) == "StateSpace{Discrete{Float64}, Float64, Matrix{Float64}}\nD = \n 4.0  0.0\n 0.0  4.0\n\nSample Time: 0.005 (seconds)\nDiscrete-time state-space model"
-                @test sprint(show, D_222) == "StateSpace{Discrete{Float64}, Float64, Matrix{Float64}}\nA = \n  0.2  -0.8\n -0.8   0.07\nB = \n 1.0  0.0\n 0.0  2.0\nC = \n 1.0  0.0\n 0.0  1.0\nD = \n 0.0  0.0\n 0.0  0.0\n\nSample Time: 0.005 (seconds)\nDiscrete-time state-space model"
+                @test sprint(show, C_222) == "StateSpace{Continuous, Int64}\nA = \n -5  -3\n  2  -9\nB = \n 1  0\n 0  2\nC = \n 1  0\n 0  1\nD = \n 0  0\n 0  0\n\nContinuous-time state-space model"
+                @test sprint(show, C_022) == "StateSpace{Continuous, Float64}\nD = \n 4.0  0.0\n 0.0  4.0\n\nContinuous-time state-space model"
+                @test sprint(show, D_022) == "StateSpace{Discrete{Float64}, Float64}\nD = \n 4.0  0.0\n 0.0  4.0\n\nSample Time: 0.005 (seconds)\nDiscrete-time state-space model"
+                @test sprint(show, D_222) == "StateSpace{Discrete{Float64}, Float64}\nA = \n  0.2  -0.8\n -0.8   0.07\nB = \n 1.0  0.0\n 0.0  2.0\nC = \n 1.0  0.0\n 0.0  1.0\nD = \n 0.0  0.0\n 0.0  0.0\n\nSample Time: 0.005 (seconds)\nDiscrete-time state-space model"
             else
-                @test sprint(show, C_222) == "StateSpace{Continuous,Int64,Array{Int64,2}}\nA = \n -5  -3\n  2  -9\nB = \n 1  0\n 0  2\nC = \n 1  0\n 0  1\nD = \n 0  0\n 0  0\n\nContinuous-time state-space model"
-                @test sprint(show, C_022) == "StateSpace{Continuous,Float64,Array{Float64,2}}\nD = \n 4.0  0.0\n 0.0  4.0\n\nContinuous-time state-space model"
-                @test sprint(show, D_022) == "StateSpace{Discrete{Float64},Float64,Array{Float64,2}}\nD = \n 4.0  0.0\n 0.0  4.0\n\nSample Time: 0.005 (seconds)\nDiscrete-time state-space model"                                            
+                @test sprint(show, C_222) == "StateSpace{Continuous,Int64}\nA = \n -5  -3\n  2  -9\nB = \n 1  0\n 0  2\nC = \n 1  0\n 0  1\nD = \n 0  0\n 0  0\n\nContinuous-time state-space model"
+                @test sprint(show, C_022) == "StateSpace{Continuous,Float64}\nD = \n 4.0  0.0\n 0.0  4.0\n\nContinuous-time state-space model"
+                @test sprint(show, D_022) == "StateSpace{Discrete{Float64},Float64}\nD = \n 4.0  0.0\n 0.0  4.0\n\nSample Time: 0.005 (seconds)\nDiscrete-time state-space model"
                 if VERSION > v"1.4.0-DEV.0" # Spurious blank space in matrix_print_row was removed in #33298
-                    @test sprint(show, D_222) == "StateSpace{Discrete{Float64},Float64,Array{Float64,2}}\nA = \n  0.2  -0.8\n -0.8   0.07\nB = \n 1.0  0.0\n 0.0  2.0\nC = \n 1.0  0.0\n 0.0  1.0\nD = \n 0.0  0.0\n 0.0  0.0\n\nSample Time: 0.005 (seconds)\nDiscrete-time state-space model"
+                    @test sprint(show, D_222) == "StateSpace{Discrete{Float64},Float64}\nA = \n  0.2  -0.8\n -0.8   0.07\nB = \n 1.0  0.0\n 0.0  2.0\nC = \n 1.0  0.0\n 0.0  1.0\nD = \n 0.0  0.0\n 0.0  0.0\n\nSample Time: 0.005 (seconds)\nDiscrete-time state-space model"
                 else
-                    @test sprint(show, D_222) == "StateSpace{Discrete{Float64},Float64,Array{Float64,2}}\nA = \n  0.2  -0.8 \n -0.8   0.07\nB = \n 1.0  0.0\n 0.0  2.0\nC = \n 1.0  0.0\n 0.0  1.0\nD = \n 0.0  0.0\n 0.0  0.0\n\nSample Time: 0.005 (seconds)\nDiscrete-time state-space model"
+                    @test sprint(show, D_222) == "StateSpace{Discrete{Float64},Float64}\nA = \n  0.2  -0.8 \n -0.8   0.07\nB = \n 1.0  0.0\n 0.0  2.0\nC = \n 1.0  0.0\n 0.0  1.0\nD = \n 0.0  0.0\n 0.0  0.0\n\nSample Time: 0.005 (seconds)\nDiscrete-time state-space model"
                 end
             end
         end


### PR DESCRIPTION
Now that we have HeteroStateSpace, there is no need for the matrix parameter in the StateSpace type. It turned out to be that it wasn't that useful since one common matrix type didn't give enough flexibility. This makes the type signature for the 99% of the cases that use StateSpace a lot nicer.

Closes #413 