### PR TITLE
Lsim gpu

### DIFF
--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -160,7 +160,7 @@ end
 @deprecate lsim(sys, u, t, x0, method) lsim(sys, u, t; x0=x0, method=method)
 
 function lsim(sys::AbstractStateSpace, u::Function, Tf::Real, args...; kwargs...)
-    t = default_time_vector(sys, Tf)
+    t = _default_time_vector(sys, Tf)
     lsim(sys, u, t, args...; kwargs...)
 end
 

--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -216,7 +216,7 @@ e.g, `x0` should prefereably not be a sparse vector.
 If `u` is a function, then `u(x,i)` is called to calculate the control signal every iteration. This can be used to provide a control law such as state feedback `u=-Lx` calculated by `lqr`. In this case, an integrer `iters` must be provided that indicates the number of iterations.
 """
 function ltitr(A::AbstractArray, B::AbstractArray, u::AbstractVecOrMat,
-        x0::AbstractVecOrMat=zeros(eltype(A), size(A, 1)))
+        x0::AbstractVecOrMat=fill!(similar(A, size(A, 1)), 0))
 
     T = promote_type(LinearAlgebra.promote_op(LinearAlgebra.matprod, eltype(A), eltype(x0)),
                       LinearAlgebra.promote_op(LinearAlgebra.matprod, eltype(B), eltype(u)))

--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -179,11 +179,10 @@ function lsim(sys::AbstractStateSpace, u::Function, t::AbstractVector;
     dt = T(t[2] - t[1])
 
     if !iscontinuous(sys) || method === :zoh
-
         if iscontinuous(sys)
             dsys = c2d(sys, dt, :zoh)
         else
-            if sys.Ts != dt 
+            if sys.Ts != dt
                 error("Time vector must match sample time for discrete system")
             end
             dsys = sys
@@ -230,7 +229,6 @@ function ltitr(A::AbstractArray, B::AbstractArray, u::AbstractVecOrMat,
     x = similar(x0, T, (length(x0), n))
 
     x[:,1] .= x0
-    # TODO something with this is slow on GPU
     x[:, 2:end] .= B * transpose(u)[:, 1:end-1] # Do all multiplications B*u[:,k] to save view allocations
 
     for k=1:n-1

--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -183,7 +183,9 @@ function lsim(sys::AbstractStateSpace, u::Function, t::AbstractVector;
         if iscontinuous(sys)
             dsys = c2d(sys, dt, :zoh)
         else
-            @assert sys.Ts == dt "Time vector must match sample time for discrete system, $(dt) ≠ $(sys.Ts)"
+            if sys.Ts != dt 
+                error("Time vector must match sample time for discrete system")
+            end
             dsys = sys
         end
         x,uout = ltitr(dsys.A, dsys.B, u, t, T.(x0))

--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -216,7 +216,7 @@ e.g, `x0` should prefereably not be a sparse vector.
 If `u` is a function, then `u(x,i)` is called to calculate the control signal every iteration. This can be used to provide a control law such as state feedback `u=-Lx` calculated by `lqr`. In this case, an integrer `iters` must be provided that indicates the number of iterations.
 """
 function ltitr(A::AbstractArray, B::AbstractArray, u::AbstractVecOrMat,
-        x0::AbstractVecOrMat=fill!(similar(A, size(A, 1)), 0))
+        x0::AbstractVecOrMat=zeros(eltype(A), size(A, 1)))
 
     T = promote_type(LinearAlgebra.promote_op(LinearAlgebra.matprod, eltype(A), eltype(x0)),
                       LinearAlgebra.promote_op(LinearAlgebra.matprod, eltype(B), eltype(u)))
@@ -238,7 +238,7 @@ function ltitr(A::AbstractArray, B::AbstractArray, u::AbstractVecOrMat,
 end
 
 function ltitr(A::AbstractArray{T}, B::AbstractArray{T}, u::Function, t,
-    x0::AbstractVecOrMat=fill!(similar(A, size(A, 1)), 0)) where T
+        x0::AbstractVecOrMat=zeros(eltype(A), size(A, 1))) where T
     iters = length(t)
     x = similar(A, size(A, 1), iters)
     uout = similar(A, size(B, 2), iters)


### PR DESCRIPTION
Changed some lsim and ltitr code so it will support CuArrays or HeteroStateSpace with CuArrays.

Ran this test on master and new branch to make sure it kept same performance on normal arrays.
```julia
using ControlSystems, BenchmarkTools

ny, nx, nu = 10, 100, 20
dt = 0.01
A = randn(nx,nx)
B = randn(nx,nu)
C = randn(ny,nx)
D = zeros(ny,nu)
sys = ss(A, B, C, D)
sysd = c2d(sys, dt)

t = 0:dt:1
x0 = zeros(nx)

tmp = ones(nu)
u(x, t) = tmp
uu = transpose(reduce(hcat, u(x0, tt) for tt in t))

@benchmark lsim(sys, u, t; x0=x0)
@benchmark lsim(sys, uu, t; x0=x0)
@benchmark lsim(sysd, u, t; x0=x0)
@benchmark lsim(sysd, uu, t; x0=x0)
```

Results on master
```julia
julia> @benchmark lsim(sys, u, t; x0=x0)
BenchmarkTools.Trial: 
  memory estimate:  881.52 KiB
  allocs estimate:  3159
  --------------
  minimum time:     1.429 ms (0.00% GC)
  median time:      1.664 ms (0.00% GC)
  mean time:        1.935 ms (7.80% GC)
  maximum time:     22.504 ms (90.67% GC)
  --------------
  samples:          2572
  evals/sample:     1

julia> @benchmark lsim(sys, uu, t; x0=x0)
BenchmarkTools.Trial: 
  memory estimate:  3.84 MiB
  allocs estimate:  106
  --------------
  minimum time:     2.052 ms (0.00% GC)
  median time:      2.321 ms (0.00% GC)
  mean time:        2.529 ms (5.97% GC)
  maximum time:     14.941 ms (75.71% GC)
  --------------
  samples:          1971
  evals/sample:     1

julia> @benchmark lsim(sysd, u, t; x0=x0)
BenchmarkTools.Trial: 
  memory estimate:  421.77 KiB
  allocs estimate:  823
  --------------
  minimum time:     824.109 μs (0.00% GC)
  median time:      916.514 μs (0.00% GC)
  mean time:        970.925 μs (3.00% GC)
  maximum time:     15.533 ms (92.07% GC)
  --------------
  samples:          5125
  evals/sample:     1

julia> @benchmark lsim(sysd, uu, t; x0=x0)
BenchmarkTools.Trial: 
  memory estimate:  105.56 KiB
  allocs estimate:  20
  --------------
  minimum time:     714.580 μs (0.00% GC)
  median time:      788.074 μs (0.00% GC)
  mean time:        813.631 μs (0.55% GC)
  maximum time:     4.152 ms (79.61% GC)
  --------------
  samples:          6111
  evals/sample:     1
```
Results on new branch
```julia
julia> @benchmark lsim(sys, u, t; x0=x0)
BenchmarkTools.Trial: 
  memory estimate:  1.61 MiB
  allocs estimate:  2815
  --------------
  minimum time:     1.451 ms (0.00% GC)
  median time:      1.544 ms (0.00% GC)
  mean time:        1.697 ms (5.76% GC)
  maximum time:     18.358 ms (87.38% GC)
  --------------
  samples:          2930
  evals/sample:     1

julia> @benchmark lsim(sys, uu, t; x0=x0)
BenchmarkTools.Trial: 
  memory estimate:  4.10 MiB
  allocs estimate:  302
  --------------
  minimum time:     2.080 ms (0.00% GC)
  median time:      2.182 ms (0.00% GC)
  mean time:        2.456 ms (6.30% GC)
  maximum time:     8.137 ms (67.88% GC)
  --------------
  samples:          2029
  evals/sample:     1

julia> @benchmark lsim(sysd, u, t; x0=x0)
BenchmarkTools.Trial: 
  memory estimate:  421.81 KiB
  allocs estimate:  827
  --------------
  minimum time:     795.230 μs (0.00% GC)
  median time:      909.728 μs (0.00% GC)
  mean time:        994.502 μs (4.15% GC)
  maximum time:     28.030 ms (95.81% GC)
  --------------
  samples:          4990
  evals/sample:     1

julia> @benchmark lsim(sysd, uu, t; x0=x0)
BenchmarkTools.Trial: 
  memory estimate:  373.31 KiB
  allocs estimate:  216
  --------------
  minimum time:     688.868 μs (0.00% GC)
  median time:      764.116 μs (0.00% GC)
  mean time:        791.641 μs (2.06% GC)
  maximum time:     11.026 ms (90.31% GC)
  --------------
  samples:          6278
  evals/sample:     1
```

This code was used to compare normal system and ones using CuArrays
```julia
using ControlSystems, BenchmarkTools, CUDA

ny, nx, nu = 100, 1000, 200
dt = 0.01
T = Float32
A  = randn(T, nx,nx)
B  = randn(T, nx,nu)
C = randn(T, ny,nx)
D = zeros(T, ny,nu)
sys = ss(A, B, C, D)
sysd = c2d(sys, dt)
sysg = HeteroStateSpace(cu(A), cu(B), cu(C), cu(D))
sysdg = HeteroStateSpace(cu(sysd.A), cu(sysd.B), cu(sysd.C), cu(sysd.D), dt)

tmp = ones(nu)
u(x, t) = tmp
tmpg = cu(ones(nu))
ug(x, t) = tmpg

x0 = zeros(nx)
x0g = cu(zeros(nx))

t = 0:dt:1

uu = transpose(reduce(hcat, u(x0, tt) for tt in t))
uug = transpose(reduce(hcat, ug(x0g, tg) for tg in t))

@benchmark lsim(sys, u, t; x0=x0)
@benchmark lsim(sysg, ug, t; x0=x0g)

@benchmark lsim(sysd, u, t; x0=x0)
@benchmark lsim(sysdg, ug, t; x0=x0g)

@benchmark lsim(sysd, uu, t; x0=x0)
@benchmark lsim(sysdg, uug, t; x0=x0g)
```
which gave this result
```julia
julia> @benchmark lsim(sys, u, t; x0=x0)
BenchmarkTools.Trial: 
  memory estimate:  18.91 MiB
  allocs estimate:  3872
  --------------
  minimum time:     81.210 ms (0.00% GC)
  median time:      96.187 ms (0.00% GC)
  mean time:        97.154 ms (1.63% GC)
  maximum time:     112.403 ms (13.90% GC)
  --------------
  samples:          52
  evals/sample:     1

julia> @benchmark lsim(sysg, ug, t; x0=x0g)
BenchmarkTools.Trial: 
  memory estimate:  3.93 MiB
  allocs estimate:  82690
  --------------
  minimum time:     29.376 ms (0.00% GC)
  median time:      30.166 ms (0.00% GC)
  mean time:        35.255 ms (2.59% GC)
  maximum time:     150.480 ms (16.68% GC)
  --------------
  samples:          142
  evals/sample:     1

julia> @benchmark lsim(sysd, u, t; x0=x0)
BenchmarkTools.Trial: 
  memory estimate:  3.70 MiB
  allocs estimate:  831
  --------------
  minimum time:     14.601 ms (0.00% GC)
  median time:      16.871 ms (0.00% GC)
  mean time:        17.373 ms (2.32% GC)
  maximum time:     43.499 ms (57.95% GC)
  --------------
  samples:          288
  evals/sample:     1

julia> @benchmark lsim(sysdg, ug, t; x0=x0g)
BenchmarkTools.Trial: 
  memory estimate:  481.30 KiB
  allocs estimate:  20107
  --------------
  minimum time:     5.606 ms (0.00% GC)
  median time:      17.440 ms (0.00% GC)
  mean time:        18.180 ms (1.11% GC)
  maximum time:     293.485 ms (18.85% GC)
  --------------
  samples:          275
  evals/sample:     1

julia> @benchmark lsim(sysd, uu, t; x0=x0)
BenchmarkTools.Trial: 
  memory estimate:  3.47 MiB
  allocs estimate:  220
  --------------
  minimum time:     10.714 ms (0.00% GC)
  median time:      12.526 ms (0.00% GC)
  mean time:        13.298 ms (2.40% GC)
  maximum time:     37.849 ms (64.22% GC)
  --------------
  samples:          376
  evals/sample:     1

julia> @benchmark lsim(sysdg, uug, t; x0=x0g)
BenchmarkTools.Trial: 
  memory estimate:  223.44 KiB
  allocs estimate:  9603
  --------------
  minimum time:     2.641 ms (0.00% GC)
  median time:      2.774 ms (0.00% GC)
  mean time:        3.348 ms (3.66% GC)
  maximum time:     301.640 ms (25.66% GC)
  --------------
  samples:          1490
  evals/sample:     1
```