### PR TITLE
Export ssdata and add test according to discussion in #471

### DIFF
--- a/src/ControlSystems.jl
+++ b/src/ControlSystems.jl
@@ -92,7 +92,8 @@ export  LTISystem,
         numpoly,
         denpoly,
         iscontinuous,
-        isdiscrete
+        isdiscrete,
+        ssdata
 
 
 # QUESTION: are these used? LaTeXStrings, Requires, IterTools

--- a/src/types/StateSpace.jl
+++ b/src/types/StateSpace.jl
@@ -188,6 +188,9 @@ HeteroStateSpace(sys::LTISystem) = convert(HeteroStateSpace, sys)
 
 # Getter functions ###################################################
 
+"""
+    `A, B, C, D = ssdata(sys)`
+"""
 ssdata(sys::AbstractStateSpace) = sys.A, sys.B, sys.C, sys.D
 
 # Funtions for number of intputs, outputs and states

--- a/test/test_discrete.jl
+++ b/test/test_discrete.jl
@@ -49,6 +49,10 @@ Gd = c2d(G, 0.2)
 @test c2d(tf(C_111), 0.01, :zoh) ≈ tf(c2d(C_111, 0.01, :zoh))
 @test c2d(tf(C_111), 0.01, :foh) ≈ tf(c2d(C_111, 0.01, :foh))
 
+# Issue #471 discussion, test c2d for zero row C
+C_210 = ss(C_212.A, C_212.B, zeros(0, 2), zeros(0, 1))
+@test c2d(C_210, 0.01).A ≈ c2d(C_212, 0.01).A
+
 # c2d on a zpk model should arguably return a zpk model
 @test_broken typeof(c2d(zpk(G), 1)) <: TransferFunction{<:ControlSystems.SisoZpk}
 


### PR DESCRIPTION
Se suggestion in #471, add export for `ssdata` and a minimal docstring as well as a test that makes sure that c2d handles state-space systems with no output dimensions.