### PR TITLE
test getting checkmark on nightly failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,11 @@ jobs:
   runtests: 
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }} 
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.version == 'nightly' }} # Allow nightly to fail and workflow still count as completed
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        version: ['1', 'nightly']
+        version: ['1', '1.5', 'nightly']
         os: [ubuntu-latest]
         arch: [x64]
     steps:
@@ -40,6 +39,7 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        continue-on-error: ${{ matrix.version == 'nightly' }} # Allow nightly to fail and workflow still count as completed
       - uses: julia-actions/julia-processcoverage@v1
         if: ${{ matrix.version == '1' }}
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1', '1.5', 'nightly']
+        version: ['1', 'nightly']
         os: [ubuntu-latest]
         arch: [x64]
     steps:


### PR DESCRIPTION
A commit is marked as failing tests even if we have continue on error for nightly, this might solve that.
Github doesn't seem to care https://github.com/actions/toolkit/issues/399