### PR TITLE
Gangof4 fixes

### DIFF
--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -788,7 +788,7 @@ function gangoffourplot(P::Union{Vector, LTISystem}, C::Vector, args...; minimal
     titles = fill("", 1, plotphase ? 8 : 4)
     # Empty titles on phase
     titleIdx = plotphase ? [1,2,5,6] : [1,2,3,4]
-    titles[titleIdx] = ["S = 1/(1+PC)", "D = P/(1+PC)", "N = C/(1+PC)", "T = PC/(1+PC)"]
+    titles[titleIdx] = ["S = 1/(1+PC)", "P/(1+PC)", "C/(1+PC)", "T = PC/(1+PC)"]
     Plots.plot!(fig, title = titles)
     return fig
 end

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -371,14 +371,15 @@ end
 
 @userplot Nyquistplot
 """
-    fig = nyquistplot(sys; gaincircles=true, kwargs...)
-    nyquistplot(LTISystem[sys1, sys2...]; gaincircles=true, kwargs...)
+    fig = nyquistplot(sys; critical_point=true, Ms_circles=Float64[], unit_circle=false, kwargs...)
+    nyquistplot(LTISystem[sys1, sys2...]; critical_point=true, Ms_circles=Float64[], unit_circle=false, kwargs...)
 
 Create a Nyquist plot of the `LTISystem`(s). A frequency vector `w` can be
 optionally provided.
 
-`gaincircles` plots the circles corresponding to |S(iω)| = 1 and |T(iω)| = 1, where S and T are
-the sensitivity and complementary sensitivity functions.
+`critical_point`, if the critical point `-1` should be indicated with a red cross
+`Ms_circles`, vector of Ms values for which Ms circles should be drawn
+`unit_circle`, if the unit circle should be displayed
 
 `kwargs` is sent as argument to plot.
 """

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -383,7 +383,7 @@ the sensitivity and complementary sensitivity functions.
 `kwargs` is sent as argument to plot.
 """
 nyquistplot
-@recipe function nyquistplot(p::Nyquistplot; gaincircles=true)
+@recipe function nyquistplot(p::Nyquistplot; critical_point=true, Ms_circles=Float64[], unit_circle=false)
     systems, w = _processfreqplot(Val{:nyquist}(), p.args...)
     ny, nu = size(systems[1])
     nw = length(w)
@@ -406,25 +406,39 @@ nyquistplot
                     hover --> [Printf.@sprintf("ω = %.3f", w) for w in w]
                     (redata, imdata)
                 end
-                # Plot rings
-                if gaincircles && si == length(systems)
-                    v = range(0,stop=2π,length=100)
-                    S,C = sin.(v),cos.(v)
+                
+                if critical_point && si == length(systems)
                     @series begin
                         primary := false
-                        linestyle := :dash
-                        linecolor := :black
-                        seriestype := :path
-                        markershape := :none
-                        (C,S)
+                        markershape := :xcross
+                        seriescolor := :red
+                        markersize := 5
+                        ([-1], [0])
                     end
+                end                
+                if !isempty(Ms_circles) && si == length(systems)
+                    θ = LinRange(0, 2π, 100)
+                    S,C = sin.(θ),cos.(θ)
+                    for Ms in Ms_circles
+                        @series begin
+                            primary := false
+                            linecolor := :gray
+                            seriestype := :path
+                            markershape := :none
+                            (-1 .+ 1/Ms * C, 1/Ms * S)
+                        end
+                    end
+                end
+                if unit_circle && si == length(systems)
+                    θ = LinRange(0, 2π, 100)
+                    S,C = sin.(θ),cos.(θ)
                     @series begin
                         primary := false
                         linestyle := :dash
                         linecolor := :black
                         seriestype := :path
                         markershape := :none
-                        (C .-1,S)
+                        (C, S)
                     end
                 end
 


### PR DESCRIPTION
Gang of four:
* Changed nonstandard naming of transfer functions.
* Avoid overly nonminal realizations when forming gang of four.

Nyquist plot:
* Added critical point
* Ability to set multiple Ms circles at arbitrary values (not just Ms=1)
* Renamed the Mt circle to unit_circle, it does not correspond to Mt = 1.