### PR TITLE
Add predictor

### DIFF
--- a/src/ControlSystems.jl
+++ b/src/ControlSystems.jl
@@ -42,6 +42,7 @@ export  LTISystem,
         similarity_transform,
         prescale,
         innovation_form,
+        noise_model,
         # Stability Analysis
         isstable,
         pole,

--- a/src/ControlSystems.jl
+++ b/src/ControlSystems.jl
@@ -42,7 +42,7 @@ export  LTISystem,
         similarity_transform,
         prescale,
         innovation_form,
-        noise_model,
+        predictor,
         # Stability Analysis
         isstable,
         pole,

--- a/src/matrix_comps.jl
+++ b/src/matrix_comps.jl
@@ -606,8 +606,8 @@ function prescale(sys::StateSpace)
 end
 
 """
-sysi = innovation_form(sys, R1, R2)
-sysi = innovation_form(sys; sysw=I, syse=I, R1=I, R2=I)
+sysi = noise_model(sys, R1, R2)
+sysi = noise_model(sys; sysw=I, syse=I, R1=I, R2=I)
 
 Takes a system
 ```
@@ -625,12 +625,33 @@ If `sysw` (`syse`) is given, the covariance resulting in filtering noise with `R
 
 See Stochastic Control, Chapter 4, Åström
 """
-function innovation_form(sys::ST, R1, R2) where ST <: AbstractStateSpace
+function noise_model(sys::ST, R1, R2) where ST <: AbstractStateSpace
     K = kalman(sys, R1, R2)
     ST(sys.A, K, sys.C, Matrix{eltype(sys.A)}(I, sys.ny, sys.ny), sys.timeevol)
 end
 # Set D = I to get transfer function H = I + C(sI-A)\ K
-function innovation_form(sys::ST; sysw=I, syse=I, R1=I, R2=I) where ST <: AbstractStateSpace
+function noise_model(sys::ST; sysw=I, syse=I, R1=I, R2=I) where ST <: AbstractStateSpace
 	K = kalman(sys, covar(sysw,R1), covar(syse, R2))
 	ST(sys.A, K, sys.C, Matrix{eltype(sys.A)}(I, sys.ny, sys.ny), sys.timeevol)
+end
+
+"""
+    innovation_form(sys::AbstractStateSpace, R1, R2)
+    innovation_form(sys::AbstractStateSpace)
+
+Return the predictor system
+x' = (A - KC)x + Bu + Ke
+y  = Cx + Du + e
+with the input equation [B K] * [u; y]
+
+See also `noise_model`.
+"""
+function innovation_form(sys::ST, R1, R2) where ST <: AbstractStateSpace
+    K = kalman(sys, R1, R2)
+    innovation_form(sys, K)
+end
+
+function ControlSystems.innovation_form(sys, K::AbstractMatrix)
+    A,B,C,D = ssdata(sys)
+    ss(A-K*C, [B K], C, [D zeros(size(D,1), size(K, 2))], sys.timeevol)
 end

--- a/src/matrix_comps.jl
+++ b/src/matrix_comps.jl
@@ -640,8 +640,8 @@ end
     predictor(sys::AbstractStateSpace, K)
 
 Return the predictor system
-x' = (A - KC)x + Bu + Ke
-y  = Cx + Du + e
+x̂' = (A - KC)x̂ + Bu + Ky
+ŷ  = Cx + Du
 with the input equation [B K] * [u; y]
 
 If covariance matrices `R1, R2` are given, the kalman gain `K` is calculaded.

--- a/test/test_matrix_comps.jl
+++ b/test/test_matrix_comps.jl
@@ -77,39 +77,39 @@ nsys, T = prescale(sys)
 @test nsys.C ≈ sys.C*T
 
 sys = ss([1 0.1; 0 1], ones(2), [1. 0], 0)
-sysn = ControlSystems.noise_model(sys, I, I)
-@test sysn.A ≈ sysn.A
-@test sysn.B ≈ [4.415675759647131
+sysi = ControlSystems.innovation_form(sys, I, I)
+@test sysi.A ≈ sysi.A
+@test sysi.B ≈ [4.415675759647131
  48.334204475215365]
 
- sysn = noise_model(sys)
- @test sysn.B ≈ [4.415675759647131
+ sysi = innovation_form(sys)
+ @test sysi.B ≈ [4.415675759647131
  48.334204475215365]
 
- sysn = noise_model(sys, R2 = 2I)
- @test sysn.B ≈ [4.225661436353894
+ sysi = innovation_form(sys, R2 = 2I)
+ @test sysi.B ≈ [4.225661436353894
  44.52445850991302]
 
- sysn = noise_model(sys, R1 = 2I)
- @test sysn.B ≈ [4.734159731874057
+ sysi = innovation_form(sys, R1 = 2I)
+ @test sysi.B ≈ [4.734159731874057
  54.719744515739514]
 
- sysn = ControlSystems.noise_model(sys, R1=2I, R2=2I)
- @test sysn.B ≈ [4.415675759647131
+ sysi = ControlSystems.innovation_form(sys, R1=2I, R2=2I)
+ @test sysi.B ≈ [4.415675759647131
  48.334204475215365]
 
 # Test with noise filters
 sysw = ss([0.5 0.1; 0 0.5], [0,1], eye_(2), 0, 1)
-sysn = ControlSystems.noise_model(sys, sysw=sysw)
-@test sysn.A ≈ sys.A
-@test sysn.B ≈ [4.01361818808572
+sysi = ControlSystems.innovation_form(sys, sysw=sysw)
+@test sysi.A ≈ sys.A
+@test sysi.B ≈ [4.01361818808572
  40.26132476965486]
 
 
 # Test innovation form
-sysi = ControlSystems.innovation_form(sys, I(2), I(1))
+sysp = ControlSystems.predictor(sys, I(2), I(1))
 K = kalman(sys, I(2), I(1))
-@test sysi.A == sys.A-K*sys.C
-@test sysi.B == [sys.B K]
+@test sysp.A == sys.A-K*sys.C
+@test sysp.B == [sys.B K]
 
 end

--- a/test/test_matrix_comps.jl
+++ b/test/test_matrix_comps.jl
@@ -77,32 +77,39 @@ nsys, T = prescale(sys)
 @test nsys.C ≈ sys.C*T
 
 sys = ss([1 0.1; 0 1], ones(2), [1. 0], 0)
-sysi = ControlSystems.innovation_form(sys, I, I)
-@test sysi.A ≈ sysi.A
-@test sysi.B ≈ [4.415675759647131
+sysn = ControlSystems.noise_model(sys, I, I)
+@test sysn.A ≈ sysn.A
+@test sysn.B ≈ [4.415675759647131
  48.334204475215365]
 
- sysi = innovation_form(sys)
- @test sysi.B ≈ [4.415675759647131
+ sysn = noise_model(sys)
+ @test sysn.B ≈ [4.415675759647131
  48.334204475215365]
 
- sysi = innovation_form(sys, R2 = 2I)
- @test sysi.B ≈ [4.225661436353894
+ sysn = noise_model(sys, R2 = 2I)
+ @test sysn.B ≈ [4.225661436353894
  44.52445850991302]
 
- sysi = innovation_form(sys, R1 = 2I)
- @test sysi.B ≈ [4.734159731874057
+ sysn = noise_model(sys, R1 = 2I)
+ @test sysn.B ≈ [4.734159731874057
  54.719744515739514]
 
- sysi = ControlSystems.innovation_form(sys, R1=2I, R2=2I)
- @test sysi.B ≈ [4.415675759647131
+ sysn = ControlSystems.noise_model(sys, R1=2I, R2=2I)
+ @test sysn.B ≈ [4.415675759647131
  48.334204475215365]
 
 # Test with noise filters
 sysw = ss([0.5 0.1; 0 0.5], [0,1], eye_(2), 0, 1)
-sysi = ControlSystems.innovation_form(sys, sysw=sysw)
-@test sysi.A ≈ sys.A
-@test sysi.B ≈ [4.01361818808572
+sysn = ControlSystems.noise_model(sys, sysw=sysw)
+@test sysn.A ≈ sys.A
+@test sysn.B ≈ [4.01361818808572
  40.26132476965486]
+
+
+# Test innovation form
+sysi = ControlSystems.innovation_form(sys, I(2), I(1))
+K = kalman(sys, I(2), I(1))
+@test sysi.A == sys.A-K*sys.C
+@test sysi.B == [sys.B K]
 
 end


### PR DESCRIPTION
This PR adds a function `predictor` that takes a kalman gain or covariance matrices and returns the system
```
x' = (A-KC)x + Bu + Ky
y = Cx + Du 
```
i.e., the one-step predictor with observer gain `K`
The predictor system will have inputs corresponding to `[u; y]`.