### PR TITLE
fix conversion for custom types

### DIFF
--- a/src/types/conversion.jl
+++ b/src/types/conversion.jl
@@ -241,7 +241,7 @@ end
 balance_transform(sys::StateSpace, perm::Bool=false) = balance_transform(sys.A,sys.B,sys.C,perm)
 
 
-convert(::Type{TransferFunction}, sys::AbstractStateSpace{TE}) where TE = convert(TransferFunction{TE,SisoRational}, sys)
+convert(::Type{TransferFunction}, sys::AbstractStateSpace{TE}) where TE = convert(TransferFunction{TE,SisoRational{numeric_type(sys)}}, sys)
 
 function convert(::Type{TransferFunction{TE,SisoRational{T}}}, sys::AbstractStateSpace) where {TE,T<:Number}
     matrix = Matrix{SisoRational{T}}(undef, size(sys))

--- a/src/types/tf.jl
+++ b/src/types/tf.jl
@@ -66,7 +66,7 @@ tf(D::AbstractArray{T}) where T = tf(D, Continuous())
 
 tf(n::Number, args...; kwargs...) = tf([n], args...; kwargs...)
 
-tf(sys::AbstractStateSpace) = convert(TransferFunction, sys) # NOTE: Would perhaps like to write TransferFunction{SisoRational}, but couldn't get this to work...
+tf(sys::AbstractStateSpace{TE}) where TE = convert(TransferFunction{TE, SisoRational{float(numeric_type(sys))}}, sys) # the call to float is required since an eigenvalue-computation is performed that produces floats from Ints etc.
 
 function tf(G::TransferFunction{TE,<:SisoTf{T}}) where {TE<:TimeEvolution,T<:Number}
     convert(TransferFunction{TE,SisoRational{T}}, G)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -8,7 +8,8 @@ numeric_type(::Type{TransferFunction{TE,S}}) where {TE,S} = numeric_type(S)
 numeric_type(::Type{<:StateSpace{TE,T}}) where {TE,T} = T
 numeric_type(::Type{<:HeteroStateSpace{TE,AT}}) where {TE,AT} = eltype(AT)
 numeric_type(::Type{<:DelayLtiSystem{T}}) where {T} = T
-numeric_type(sys::LTISystem) = eltype(sys.A)
+numeric_type(sys::AbstractStateSpace) = eltype(sys.A)
+numeric_type(sys::LTISystem) = numeric_type(typeof(sys))
 
 
 to_matrix(T, A::AbstractVector) = Matrix{T}(reshape(A, length(A), 1))

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -8,7 +8,7 @@ numeric_type(::Type{TransferFunction{TE,S}}) where {TE,S} = numeric_type(S)
 numeric_type(::Type{<:StateSpace{TE,T}}) where {TE,T} = T
 numeric_type(::Type{<:HeteroStateSpace{TE,AT}}) where {TE,AT} = eltype(AT)
 numeric_type(::Type{<:DelayLtiSystem{T}}) where {T} = T
-numeric_type(sys::LTISystem) = numeric_type(typeof(sys))
+numeric_type(sys::LTISystem) = eltype(sys.A)
 
 
 to_matrix(T, A::AbstractVector) = Matrix{T}(reshape(A, length(A), 1))

--- a/test/framework.jl
+++ b/test/framework.jl
@@ -1,3 +1,4 @@
+using ControlSystems
 # Local definition to make sure we get warnings if we use eye
 eye_(n) = Matrix{Int64}(I, n, n)
 


### PR DESCRIPTION
There was a type parameter missing in the convert method, this led to the method below never being called. 
I also changed the implentation for the fallback `numeric_type(sys::LTISystem)` to just grab the numeric type from the A-matrix of the system. This will never be called for our types, but it will make sure `numeric_type` works for all custom StateSpace types even if they haven't implemented `numeric_type(::Type{CustomStateSpace})`