### PR TITLE
implement minreal through Kalman decomposition

### DIFF
--- a/src/types/StateSpace.jl
+++ b/src/types/StateSpace.jl
@@ -425,14 +425,14 @@ function minreal(sys::ST,
     nnc = size(nullspace(C'; atol, rtol), 2) # number of non-controllable modes
     nc = sys.nx-nnc
 
-    nno = size(nullspace(O; atol, rtol), 2) # number of non-controllable modes
+    nno = size(nullspace(O; atol, rtol), 2) # number of non-observable modes
     no = sys.nx-nno
 
     T1 = diagonalizing(P, true)
 
     Q_block = inv(T1')*Q* inv(T1)
 
-    Q11 = Q_block[1:nc, 1:nc] # TODO: I just guessed to put no here
+    Q11 = Q_block[1:nc, 1:nc] 
     U1 = diagonalizing(Q11, false)
 
     Σ12b = abs.(diag(U1*Q11*U1')) # should be block(Σ₁², 0) 

--- a/test/test_simplification.jl
+++ b/test/test_simplification.jl
@@ -29,4 +29,83 @@ y1,x1 = step(sys,t)[[1,3]]
 y2,x2 = step(sysmin,t)[[1,3]]
 @test sum(abs2,y1.-y2) < 1e-6 # Test that the output from the two systems are the same
 
+
+
+import LinearAlgebra.eigsortby
+polecompare(sys1, sys2) = isapprox(sort(pole(sys1), by=eigsortby), sort(pole(sys2), by=eigsortby), atol=1e-3)
+
+almost_diagonal(X) = norm(X-diagm(diag(X))) < sqrt(eps())
+
+##
+Random.seed!(0)
+sys = ssrand(1,1,2)
+sysr = minreal(sys)
+@test polecompare(sys, sysr)
+@test almost_diagonal(gram(sysr, :c))
+
+sys = [sys sys] # unobservable
+sysr = minreal(sys)
+@test sysr.nx == 2
+@test polecompare(sys, [sysr sysr])
+@test almost_diagonal(gram(sysr, :c))
+
+sys = ssrand(1,1,2)
+sys = [sys; sys] # uncontrollable
+sysr = minreal(sys)
+@test sysr.nx == 2
+@test polecompare(sys, [sysr sysr])
+@test almost_diagonal(gram(sysr, :c))
+
+# MIMO
+
+sys = ssrand(2,3,4)
+sysr = minreal(sys)
+@test polecompare(sys, sysr)
+@test almost_diagonal(gram(sysr, :c))
+
+sys = [sys sys] # unobservable
+sysr = minreal(sys)
+@test sysr.nx == 4
+@test polecompare(sys, [sysr sysr])
+@test almost_diagonal(gram(sysr, :c))
+
+sys = ssrand(2,3,4)
+sys = [sys; sys] # uncontrollable
+sysr = minreal(sys)
+@test sysr.nx == 4
+@test polecompare(sys, [sysr sysr])
+@test almost_diagonal(gram(sysr, :c))
+
+
+sys = [sys 2sys] 
+sysr = minreal(sys)
+@test sysr.nx == 4
+@test almost_diagonal(gram(sysr, :c))
+
+
+
+@testset "diagonalizing" begin
+    @info "Testing diagonalizing"
+    import ControlSystems: diagonalizing
+    P = randn(3,3)
+    P = P'P
+    T = diagonalizing(P, true)
+    @test T*P*T' ≈ I
+
+    T = diagonalizing(P, false)
+    TP = T*P*T'
+    @test sum(abs, TP - diagm(diag(TP))) < 1e-10
+
+    P = randn(2, 3)
+    P = P'P
+    T = diagonalizing(P, true)
+    @test T*P*T' ≈ ControlSystems.blockdiag(1.0I(2), 0.0I(1))
+
+    T = diagonalizing(P, false)
+    TP = T*P*T'
+    @test sum(abs, TP - diagm(diag(TP))) < 1e-10
+
+    display(T*P*T')
+end
+
 end


### PR DESCRIPTION
The old `minreal` failed if the realization wasn't minimal, which kind of defeats the purpose of the function. 
