### PR TITLE
Remove asserts

### DIFF
--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -75,7 +75,7 @@ Compute the determinant of the Matrix `sys` of SisoTf systems, returns a SisoTf 
 # TODO: improve this implementation, should be more efficient ones
 function det(sys::Matrix{S}) where {S<:SisoZpk}
     ny, nu = size(sys)
-    @assert ny == nu "Matrix is not square"
+    ny == nu || error("sys matrix is not square")
     if ny == 1
         return sys[1, 1]
     end

--- a/src/freqresp.jl
+++ b/src/freqresp.jl
@@ -79,7 +79,7 @@ function (sys::TransferFunction)(s)
 end
 
 function (sys::TransferFunction)(z_or_omega::Number, map_to_unit_circle::Bool)
-    @assert isdiscrete(sys) "It only makes no sense to call this function with discrete systems"
+    isdiscrete(sys) || error("It only makes no sense to call this function with discrete systems")
     if map_to_unit_circle
         isreal(z_or_omega) ? evalfr(sys,exp(im*z_or_omega.*sys.Ts)) : error("To map to the unit circle, omega should be real")
     else
@@ -88,7 +88,7 @@ function (sys::TransferFunction)(z_or_omega::Number, map_to_unit_circle::Bool)
 end
 
 function (sys::TransferFunction)(z_or_omegas::AbstractVector, map_to_unit_circle::Bool)
-    @assert isdiscrete(sys) "It only makes no sense to call this function with discrete systems"
+    isdiscrete(sys) || error("It only makes no sense to call this function with discrete systems")
     vals = sys.(z_or_omegas, map_to_unit_circle)# evalfr.(sys,exp.(evalpoints))
     # Reshape from vector of evalfr matrizes, to (in,out,freq) Array
     nu,ny = size(vals[1])

--- a/src/pid_design.jl
+++ b/src/pid_design.jl
@@ -160,7 +160,7 @@ function laglink(a, M; h=nothing, Ts=0)
         Base.depwarn("`laglink($a, $M; h=$h)` is deprecated, use `laglink($a, $M; Ts=$h)` instead.", Core.Typeof(laglink).name.mt.name)
         Ts = h
     end
-    @assert Ts ≥ 0 "Negative `Ts` is not supported."
+    Ts ≥ 0 || error("Negative `Ts` is not supported.")
     numerator = [1/a, 1]
     denominator = [M/a, 1]
     gain = M
@@ -185,7 +185,7 @@ function leadlink(b, N, K; h=nothing, Ts=0)
         Base.depwarn("`leadlink($b, $N, $K; h=$h)` is deprecated, use `leadlink($b, $N, $K; Ts=$h)` instead.", Core.Typeof(leadlink).name.mt.name)
         Ts = h
     end
-    @assert Ts ≥ 0 "Negative `Ts` is not supported."
+    Ts ≥ 0 || error("Negative `Ts` is not supported.")
     numerator = [1/b, 1]
     denominator = [1/(b*N), 1]
     gain = K

--- a/src/simulators.jl
+++ b/src/simulators.jl
@@ -37,7 +37,7 @@ plot(t, s.y(sol, t)[:], lab="Open loop step response")
 ```
 """
 function Simulator(P::AbstractStateSpace, u::F = (x,t) -> 0) where F
-    @assert iscontinuous(P) "Simulator only supports continuous-time system. See function `lsim` for simulation of discrete-time systems."
+    iscontinuous(P) || error("Simulator only supports continuous-time system. See function `lsim` for simulation of discrete-time systems.")
     f = (dx,x,p,t) -> dx .= P.A*x .+ P.B*u(x,t)
     y(x,t) = P.C*x .+ P.D*u(x,t)
     y(sol::ODESolution,t) = P.C*sol(t) .+ P.D*u(sol(t),t)

--- a/src/types/SisoTfTypes/SisoZpk.jl
+++ b/src/types/SisoTfTypes/SisoZpk.jl
@@ -13,8 +13,8 @@ struct SisoZpk{T,TR<:Number} <: SisoTf{T}
         end
         if TR <: Complex && T <: Real
             z, p = copy(z), copy(p)
-            @assert pairup_conjugates!(z) "zpk model should be real-valued, but zeros do not come in conjugate pairs."
-            @assert pairup_conjugates!(p) "zpk model should be real-valued, but poles do not come in conjugate pairs."
+            pairup_conjugates!(z) || throw(ArgumentError("zpk model should be real-valued, but zeros do not come in conjugate pairs."))
+            pairup_conjugates!(p) || throw(ArgumentError("zpk model should be real-valued, but poles do not come in conjugate pairs."))
         end
         new{T,TR}(z, p, k)
     end

--- a/src/types/zpk.jl
+++ b/src/types/zpk.jl
@@ -44,21 +44,15 @@ function zpk(z::AbstractVector{TZ}, p::AbstractVector{TP}, k::T, Ts::TE) where {
 end
 
 function zpk(z::AbstractVector, p::AbstractVector, k::T, Ts::TE) where {TE<:TimeEvolution, T<:Number} # To be able to send in empty vectors [] of type Any
-    if eltype(z) == Any && eltype(p) == Any
-        @assert z == []
-        @assert p == []
-        return zpk(T[], T[], k, Ts)
-    elseif eltype(z) == Any
-        @assert z == []
-        TR = eltype(p)
-        return zpk(TR[], p, k, Ts)
-    elseif eltype(p) == Any
-        @assert p == []
-        TR = eltype(z)
-        return zpk(z, TR[], k, Ts)
-    else
-        error("Non numeric vectors must be empty.")
+    if eltype(z) == Any 
+        z == [] || error("non numeric vectors must be empty.")
+        z = T[]
     end
+    if eltype(p) == Any 
+        p == [] || error("non numeric vectors must be empty.")
+        p = T[]
+    end
+    zpk(z, p, k, Ts)
 end
 
 function zpk(gain::Matrix{T}, Ts::TE; kwargs...) where {TE<:TimeEvolution, T <: Number}

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -77,7 +77,7 @@ function roots2real_poly_factors(roots::Vector{cT}) where cT <: Number
             end
 
             if k == length(roots) || r != conj(roots[k+1])
-                throw(AssertionError("Found pole without matching conjugate."))
+                throw(ArgumentError("Found pole without matching conjugate."))
             end
 
             push!(poly_factors,Polynomial{T}([real(r)^2+imag(r)^2, -2*real(r), 1]))

--- a/test/test_complex.jl
+++ b/test/test_complex.jl
@@ -23,7 +23,7 @@ C_2 = zpk([-1+im], [], 1.0+1im)
 @test minreal(zpk([-1+im, -1+im], [-1+im],1+1im)) == zpk([-1+im], [], 1+1im)
 
 
-@test_throws AssertionError zpk([-1+im], [-1+im,-1+im],1) #  Given the type of k this should be a real-coefficient system, but poles and zeros don't come in conjugate pairs
+@test_throws ArgumentError zpk([-1+im], [-1+im,-1+im],1) #  Given the type of k this should be a real-coefficient system, but poles and zeros don't come in conjugate pairs
 
 @test zpk([-2+im], [-1+im],1+0im)*zpk([], [-1+im],1+0im) == zpk([-2+im], [-1+im, -1+im], 1+0im)
 @test zpk([], [-2], 2) + zpk([], [-1], 1) == zpk([-4/3], [-2,-1], 3)

--- a/test/test_zpk.jl
+++ b/test/test_zpk.jl
@@ -43,7 +43,7 @@ z = zpk("z", 0.005)
 @test zpk([], [1.0+im,1.0,1.0-im], 1.0) == zpk(ComplexF64[], [1.0+im,1.0-im,1.0], 1.0)
 @test zpk([1.0-im,1.0,1.0+im], [], 1.0) == zpk([1.0+im,1.0-im,1.0], ComplexF64[], 1.0)
 @test zpk([], [1.0+im,1.0,1.0+im,1.0-im,1.0-im], 1.0) == zpk(ComplexF64[], [1.0+im,1.0-im,1.0+im,1.0-im,1.0], 1.0)
-@test_throws AssertionError zpk([], [1.01+im,1.0-im], 1.0) 
+@test_throws ArgumentError zpk([], [1.01+im,1.0-im], 1.0) 
 
 
 #TODO improve polynomial accuracy se these are equal


### PR DESCRIPTION
Read in the [docs](https://docs.julialang.org/en/v1/base/base/#Base.@assert) that assert was suggested to only be used for debugging since it can be disabled at some optimization levels. We had some argument checks where the function is only supposed to work under some criteria which was implemented with `@assert`, had a quick go at exchanging them for `error` instead.

