### PR TITLE
Update to fix margin

### DIFF
--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -411,11 +411,8 @@ end
 
 function _allPhaseCrossings(w, phase)
     #Calculate numer of times real axis is crossed on negative side
-    n =  Vector{eltype(w)}(undef, length(w)) #Nbr of crossed
-    ph = Vector{eltype(w)}(undef, length(w)) #Residual
-    for i = eachindex(w) #Found no easier way to do this
-        n[i], ph[i] = fldmod(phase[i]+180,360)#+180
-    end
+    n = fld.(phase.+180,360) #Nbr of crossed
+    ph = mod.(phase,360) .- 180 #Residual
     _findCrossings(w, n, ph)
 end
 


### PR DESCRIPTION
Phase crossings of -180 was off by one index, this should fix it.

```julia
s = tf("s");
sys = 1/(s+1)^3
wgm, gm, = margin(sys)
```
previously gives `[1.682043930555656], [7.493320140213881]`
where `imag(sys(wgm[]*im)[])` is 5.11e-3.
The new change gives
`[1.7324045892274331], [8.003677263985244]` with `imag(sys(wgm[]*im)[])` roughly `3.31e-5`

Edit: True value should be `wgm=sqrt(3)=1.73205`, and `gm=8`