### PR TITLE
return similarity transform from `balreal`

### DIFF
--- a/src/matrix_comps.jl
+++ b/src/matrix_comps.jl
@@ -168,8 +168,9 @@ function covar(sys::AbstractStateSpace, W)
     func = iscontinuous(sys) ? lyap : dlyap
     Q = try
         func(A, B*W*B')
-    catch
-        error("No solution to the Lyapunov equation was found in covar")
+    catch e
+        @error("No solution to the Lyapunov equation was found in covar.")
+        rethrow(e)
     end
     P = C*Q*C'
     if !isdiscrete(sys)

--- a/src/matrix_comps.jl
+++ b/src/matrix_comps.jl
@@ -494,9 +494,9 @@ end
 
 
 """
-`sysr, G = balreal(sys::StateSpace)`
+`sysr, G, T = balreal(sys::StateSpace)`
 
-Calculates a balanced realization of the system sys, such that the observability and reachability gramians of the balanced system are equal and diagonal `G`
+Calculates a balanced realization of the system sys, such that the observability and reachability gramians of the balanced system are equal and diagonal `G`. `T` is the similarity transform between the old state `x` and the newstate `z` such that `Tz = x`.
 
 See also `gram`, `baltrunc`
 
@@ -532,14 +532,16 @@ function balreal(sys::ST) where ST <: AbstractStateSpace
         display(Σ)
     end
 
-    sysr = ST(T*sys.A/T, T*sys.B, sys.C/T, sys.D, sys.timeevol), diagm(0 => Σ)
+    sysr = ST(T*sys.A/T, T*sys.B, sys.C/T, sys.D, sys.timeevol), diagm(Σ), T
 end
 
 
 """
-    sysr, G = baltrunc(sys::StateSpace; atol = √ϵ, rtol=1e-3, unitgain=true, n = nothing)
+    sysr, G, T = baltrunc(sys::StateSpace; atol = √ϵ, rtol=1e-3, unitgain=true, n = nothing)
 
 Reduces the state dimension by calculating a balanced realization of the system sys, such that the observability and reachability gramians of the balanced system are equal and diagonal `G`, and truncating it to order `n`. If `n` is not provided, it's chosen such that all states corresponding to singular values less than `atol` and less that `rtol σmax` are removed.
+
+`T` is the similarity transform between the old state `x` and the newstate `z` such that `Tz = x`.
 
 If `unitgain=true`, the matrix `D` is chosen such that unit static gain is achieved.
 
@@ -548,7 +550,7 @@ See also `gram`, `balreal`
 Glad, Ljung, Reglerteori: Flervariabla och Olinjära metoder
 """
 function baltrunc(sys::ST; atol = sqrt(eps()), rtol = 1e-3, unitgain = true, n = nothing) where ST <: AbstractStateSpace
-    sysbal, S = balreal(sys)
+    sysbal, S, T = balreal(sys)
     S = diag(S)
     if n === nothing
         S = S[S .>= atol]
@@ -565,7 +567,7 @@ function baltrunc(sys::ST; atol = sqrt(eps()), rtol = 1e-3, unitgain = true, n =
         D = D/(C*inv(-A)*B)
     end
 
-    return ST(A,B,C,D,sys.timeevol), diagm(0 => S)
+    return ST(A,B,C,D,sys.timeevol), diagm(S), T
 end
 
 """

--- a/src/matrix_comps.jl
+++ b/src/matrix_comps.jl
@@ -496,7 +496,7 @@ end
 """
 `sysr, G, T = balreal(sys::StateSpace)`
 
-Calculates a balanced realization of the system sys, such that the observability and reachability gramians of the balanced system are equal and diagonal `G`. `T` is the similarity transform between the old state `x` and the newstate `z` such that `Tz = x`.
+Calculates a balanced realization of the system sys, such that the observability and reachability gramians of the balanced system are equal and diagonal `G`. `T` is the similarity transform between the old state `x` and the new state `z` such that `Tz = x`.
 
 See also `gram`, `baltrunc`
 


### PR DESCRIPTION
Because it's useful to have if other things need transformation as well, e.g., Kalman gain or covariance matrices.

Also, this PR rethrows the full error if `covar` fails, catching the error and providing much less information in it's place is not good practice.