### PR TITLE
Move plot globals to runtests

### DIFF
--- a/test/framework.jl
+++ b/test/framework.jl
@@ -1,3 +1,11 @@
+# Set plot globals
+ENV["PLOTS_TEST"] = "true"
+ENV["GKSwstype"] = "nul"
+
+using Plots
+gr()
+default(show=false)
+
 using ControlSystems
 # Local definition to make sure we get warnings if we use eye
 eye_(n) = Matrix{Int64}(I, n, n)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,3 @@
-# Set plot globals
-ENV["PLOTS_TEST"] = "true"
-ENV["GKSwstype"] = "nul"
-
-using Plots
-gr()
-default(show=false)
-
 using ControlSystems
 using Test, LinearAlgebra, Random
 import Base.isapprox        # In framework and test_synthesis

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,11 @@
+# Set plot globals
+ENV["PLOTS_TEST"] = "true"
+ENV["GKSwstype"] = "nul"
+
+using Plots
+gr()
+default(show=false)
+
 using ControlSystems
 using Test, LinearAlgebra, Random
 import Base.isapprox        # In framework and test_synthesis

--- a/test/test_plots.jl
+++ b/test/test_plots.jl
@@ -1,11 +1,3 @@
-# Set plot globals
-ENV["PLOTS_TEST"] = "true"
-ENV["GKSwstype"] = "nul"
-
-using Plots
-gr()
-default(show=false)
-
 # This function show mirror that in ControlExamplePlots.jl/genplots.jl
 # to make sure that the plots in these tests can be tested for accuracy
 """funcs, names = getexamples()


### PR DESCRIPTION
There is plotting done in more tests than `test_plots.jl`, and `test_plots` is last in the list of tests. So for the other tests that run plot commands they will not have set up the globals correctly and I think this might help with all the `GKS: GKS not in proper state. GKS must be either in the state WSAC or SGOP in routine ...` messages spamming the CI.