### PR TITLE
Fix struct_ctrb_obsv

### DIFF
--- a/src/simplification.jl
+++ b/src/simplification.jl
@@ -26,11 +26,9 @@ end
 # structurally controllable.
 function struct_ctrb_states(A::AbstractVecOrMat, B::AbstractVecOrMat)
     bitA = A .!= 0
-    d_cvec = cvec = vec(any(B .!= 0, dims=2))
-    while any(d_cvec .!= 0)
-        Adcvec = vec(any(bitA[:, findall(d_cvec)], dims=2))
-        cvec = cvec .| Adcvec
-        d_cvec = Adcvec .& .~cvec
+    x = vec(any(B .!= 0, dims=2)) # indexs vector indicating states that have been affected by input
+    for i = 1:size(A, 1) # apply A nx times, similar to controllability matrix
+        x = (bitA * x) .!= 0
     end
-    return cvec
+    x
 end

--- a/test/test_simplification.jl
+++ b/test/test_simplification.jl
@@ -8,6 +8,9 @@ G = ss([-5 0 0 0; 0 -1 -2.5 0; 0 4 0 0; 0 0 0 -6], [2 0; 0 1; 0 0; 0 2],
 @test sminreal(G[2, 1]) == ss([-5], [2], [-2], [1])
 @test sminreal(G[2, 2]) == ss([-6], [2], [1], [0])
 
+using ControlSystems.DemoSystems: resonant
+R = resonant()*resonant()
+@test sminreal(R) == R # https://github.com/JuliaControl/ControlSystems.jl/issues/409
 
 ## MINREAL ##
 


### PR DESCRIPTION
I didn't quite understand the old implementation of `struct_ctrb_obsv` so I reimplemented it completely. This version passes the tests, and the additional test that was previously failing from #409. 

The algorithm maintains a bitvector with state indices that have been affected by the input. It applies the `A` matrix `nx` times, corresponding roughly to calculating the last block of the controllability matrix. After this, the bit vector will indicate the structurally controllable states.

closes #409