### PR TITLE
write `struct_ctrb_states` in terms of `iszero` instead of `== 0`

### DIFF
--- a/src/simplification.jl
+++ b/src/simplification.jl
@@ -42,7 +42,7 @@ function struct_ctrb_states(A::AbstractVecOrMat, B::AbstractVecOrMat)
     bitA = .!iszero.(A)
     x = vec(any(B .!= 0, dims=2)) # index vector indicating states that have been affected by input
     for i = 1:size(A, 1) # apply A nx times, similar to controllability matrix
-        x = .!iszero(x .| (bitA * x))
+        x = x .| .!iszero.(bitA * x)
     end
     x
 end


### PR DESCRIPTION
The reason is that `iszero` always returns a bool, whereas `== 0` may return anything. The difference appears for symbolic variables where
```julia
julia> q0 == 0
q0(t) == 0

julia> iszero(q0)
false
```