### PR TITLE
Remove double doctest run, add strict doctest

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,15 +44,7 @@ jobs:
             using Pkg
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
-      - name: Test docs # Test are also run in the makedocs, but there they don't error properly unless we set strict in which case warnings also error
-        run: |
-          julia --project=docs -e '
-            ENV["PLOTS_TEST"] = "true"
-            ENV["GKSwstype"] = "nul"
-            using Documenter: doctest
-            using ControlSystems
-            doctest(ControlSystems)'
-      - name: Generate documentation
+      - name: Make documentation, run doctest
         run: julia --project=docs --color=yes docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -30,7 +30,13 @@ println("Making docs")
 makedocs(modules=[ControlSystems],
     format=Documenter.HTML(),
     sitename="ControlSystems.jl",
-    #strict=true,
+    strict=[
+        :doctest, 
+        :linkcheck, 
+        :parse_error, 
+        # Other available options are
+        # :autodocs_block, :cross_references, :docs_block, :eval_block, :example_block, :footnote, :meta_block, :missing_docs, :setup_block
+    ],
     pages=[
         "Home" => "index.md",
         "Guide" => Any[


### PR DESCRIPTION
A recently merged [PR](https://github.com/JuliaDocs/Documenter.jl/pull/1689) in Documenter.jl allows for setting strict checking on certain errors. 

We currently ran doctest by itself first before running it when generating documentation, I think this means we would not need to. 

Just testing this for now, might need to figure out which errors we should use.