### PR TITLE
pole->poles tzero->tzeros

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Some of the available commands are:
 ##### Constructing systems
 ss, tf, zpk
 ##### Analysis
-pole, tzero, norm, hinfnorm, linfnorm, ctrb, obsv, gangoffour, margin, markovparam, damp, dampreport, zpkdata, dcgain, covar, gram, sigma, sisomargin
+poles, tzeros, norm, hinfnorm, linfnorm, ctrb, obsv, gangoffour, margin, markovparam, damp, dampreport, zpkdata, dcgain, covar, gram, sigma, sisomargin
 ##### Synthesis
 care, dare, dlyap, lqr, dlqr, place, leadlink, laglink, leadlinkat, rstd, rstc, dab, balreal, baltrunc
 ###### PID design

--- a/src/ControlSystems.jl
+++ b/src/ControlSystems.jl
@@ -45,8 +45,8 @@ export  LTISystem,
         observer_controller,
         # Stability Analysis
         isstable,
-        pole,
-        tzero,
+        poles,
+        tzeros,
         dcgain,
         zpkdata,
         damp,
@@ -170,6 +170,8 @@ include("delay_systems.jl")
 
 include("plotting.jl")
 
+@deprecate pole poles
+@deprecate tzero tzeros
 @deprecate num numvec
 @deprecate den denvec
 @deprecate norminf hinfnorm

--- a/src/delay_systems.jl
+++ b/src/delay_systems.jl
@@ -224,7 +224,7 @@ function _default_dt(sys::DelayLtiSystem)
     if !isstable(sys.P.P)
         return 0.05   # Something small
     else
-        ps = pole(sys.P.P)
+        ps = poles(sys.P.P)
         r = minimum([abs.(real.(ps));0]) # Find the fastest pole of sys.P.P
         r = min(r, minimum([sys.Tau;0])) # Find the fastest delay
         if r == 0.0

--- a/src/freqresp.jl
+++ b/src/freqresp.jl
@@ -156,7 +156,7 @@ function _bounds_and_features(sys::LTISystem, plot::Val)
         zp = zp[imag(zp) .>= 0.0]
     else
          # For sigma plots, use the MIMO poles and zeros
-         zp = [tzero(sys); pole(sys)]
+         zp = [tzeros(sys); poles(sys)]
     end
     # Get the frequencies of the features, ignoring low frequency dynamics
     fzp = log10.(abs.(zp))

--- a/src/matrix_comps.jl
+++ b/src/matrix_comps.jl
@@ -298,7 +298,7 @@ function _infnorm_two_steps_ct(sys::AbstractStateSpace, normtype::Symbol, tol=1e
         return (T(opnorm(sys.D)), T(0))
     end
 
-    pole_vec = pole(sys)
+    pole_vec = poles(sys)
 
     # Check if there is a pole on the imaginary axis
     pidx = findfirst(on_imag_axis, pole_vec)
@@ -380,7 +380,7 @@ function _infnorm_two_steps_dt(sys::AbstractStateSpace, normtype::Symbol, tol=1e
         return (T(opnorm(sys.D)), Tw(0))
     end
 
-    pole_vec = pole(sys)
+    pole_vec = poles(sys)
 
     # Check if there is a pole on the unit circle
     pidx = findfirst(on_unit_circle, pole_vec)

--- a/src/pid_design.jl
+++ b/src/pid_design.jl
@@ -115,7 +115,7 @@ rlocus
 @recipe function rlocus(p::Rlocusplot; K=500)
     P = p.args[1]
     K = K isa Number ? range(1e-6,stop=K,length=10000) : K
-    Z = tzero(P)
+    Z = tzeros(P)
     poles, K = getpoles(P,K)
     redata = real.(poles)
     imdata = imag.(poles)

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -747,8 +747,8 @@ pzmap
     title --> "Pole-zero map"
     legend --> false
     for (i, system) in enumerate(systems)
-        p = pole(system)
-        z = tzero(system)
+        p = poles(system)
+        z = tzeros(system)
         if !isempty(z)
             @series begin
                 group --> i

--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -270,10 +270,10 @@ end
 function _default_dt(sys::LTISystem)
     if isdiscrete(sys)
         return sys.Ts
-    elseif all(iszero, pole(sys)) # Static or pure integrators
+    elseif all(iszero, poles(sys)) # Static or pure integrators
         return 0.05
     else
-        ω0_max = maximum(abs.(pole(sys)))
+        ω0_max = maximum(abs.(poles(sys)))
         dt = round(1/(12*ω0_max), sigdigits=2)
         return dt
     end

--- a/src/types/Lti.jl
+++ b/src/types/Lti.jl
@@ -85,11 +85,11 @@ common_timeevol(systems::LTISystem...) = common_timeevol(timeevol(sys) for sys i
 Returns `true` if `sys` is stable, else returns `false`."""
 function isstable(sys::LTISystem)
     if iscontinuous(sys)
-        if any(real.(pole(sys)).>=0)
+        if any(real.(poles(sys)).>=0)
             return false
         end
     else
-        if any(abs.(pole(sys)).>=1)
+        if any(abs.(poles(sys)).>=1)
             return false
         end
     end

--- a/src/types/SisoTfTypes/SisoRational.jl
+++ b/src/types/SisoTfTypes/SisoRational.jl
@@ -76,8 +76,8 @@ denvec(f::SisoRational) = reverse(coeffs(f.den))
 denpoly(f::SisoRational) = f.den
 numpoly(f::SisoRational) = f.num
 
-tzero(f::SisoRational) = roots(f.num)
-pole(f::SisoRational) = roots(f.den)
+tzeros(f::SisoRational) = roots(f.num)
+poles(f::SisoRational) = roots(f.den)
 
 function evalfr(f::SisoRational{T}, s::Number) where T
     S = promote_op(/, promote_type(T, typeof(s)), promote_type(T, typeof(s)))

--- a/src/types/SisoTfTypes/SisoZpk.jl
+++ b/src/types/SisoTfTypes/SisoZpk.jl
@@ -44,9 +44,9 @@ Base.one(f::SisoZpk) = one(typeof(f))
 Base.zero(f::SisoZpk) = zero(typeof(f))
 
 
-# tzero is not meaningful for transfer function element? But both zero and zeros are taken...
-tzero(f::SisoZpk) = f.z # Do minreal first?,
-pole(f::SisoZpk) = f.p # Do minreal first?
+# tzeros is not meaningful for transfer function element? But both zero and zeros are taken...
+tzeros(f::SisoZpk) = f.z # Do minreal first?,
+poles(f::SisoZpk) = f.p # Do minreal first?
 
 numpoly(f::SisoZpk{<:Real}) = f.k*prod(roots2real_poly_factors(f.z))
 denpoly(f::SisoZpk{<:Real}) = prod(roots2real_poly_factors(f.p))

--- a/src/types/conversion.jl
+++ b/src/types/conversion.jl
@@ -285,7 +285,7 @@ Convert get zpk representation of sys from input j to output i
 function siso_ss_to_zpk(sys, i, j)
     A, B, C = struct_ctrb_obsv(sys.A, sys.B[:, j:j], sys.C[i:i, :])
     D = sys.D[i:i, j:j]
-    z = tzero(A, B, C, D)
+    z = tzeros(A, B, C, D)
     nx = size(A, 1)
     nz = length(z)
     k = nz == nx ? D[1] : (C*(A^(nx - nz - 1))*B)[1]

--- a/test/test_analysis.jl
+++ b/test/test_analysis.jl
@@ -1,5 +1,5 @@
 @testset "test_analysis" begin
-## TZERO ##
+## tzeros ##
 # Examples from the Emami-Naeini & Van Dooren Paper
 # Example 3
 A = [0 1 0 0 0 0;
@@ -16,7 +16,7 @@ D = [1 0;
      1 0]
 
 ex_3 = ss(A, B, C, D)
-@test tzero(ex_3) ≈ [0.3411639019140099 + 1.161541399997252im,
+@test tzeros(ex_3) ≈ [0.3411639019140099 + 1.161541399997252im,
                              0.3411639019140099 - 1.161541399997252im,
                              0.9999999999999999 + 0.0im,
                              -0.6823278038280199 + 0.0im]
@@ -35,13 +35,13 @@ C = [1 0 0 0 0;
      0 1 0 0 0]
 D = zeros(2, 2)
 ex_4 = ss(A, B, C, D)
-@test tzero(ex_4) ≈ [-0.06467751189940692,-0.3680512036036696]
+@test tzeros(ex_4) ≈ [-0.06467751189940692,-0.3680512036036696]
 
 # Example 5
 s = tf("s")
 ex_5 = 1/s^15
-@test tzero(ex_5) == Float64[]
-@test tzero(ss(ex_5)) == Float64[]
+@test tzeros(ex_5) == Float64[]
+@test tzeros(ss(ex_5)) == Float64[]
 
 # Example 6
 A = [2 -1 0;
@@ -51,13 +51,13 @@ B = [0; 0; 1]
 C = [0 -1 0]
 D = [0]
 ex_6 = ss(A, B, C, D)
-@test tzero(ex_6) == Float64[]
+@test tzeros(ex_6) == Float64[]
 
 @test ss(A, [0 0 1]', C, D) == ex_6
 
 # Example 7
 ex_7 = ss(zeros(2, 2), [0;1], [-1 0], [0])
-@test tzero(ex_7) == Float64[]
+@test tzeros(ex_7) == Float64[]
 
 # Example 8
 A = [-2 1 0 0 0 0;
@@ -71,12 +71,12 @@ C = [0 0 0 1 0 0]
 D = [0]
 ex_8 = ss(A, B, C, D)
 # TODO : there may be a way to improve the precision of this example.
-@test tzero(ex_8) ≈ [-1.0, -1.0] atol=1e-7
+@test tzeros(ex_8) ≈ [-1.0, -1.0] atol=1e-7
 
 # Example 9
 ex_9 = (s - 20)/s^15
-@test tzero(ex_9) ≈ [20.0]
-@test tzero(ss(ex_9)) ≈ [20.0]
+@test tzeros(ex_9) ≈ [20.0]
+@test tzeros(ss(ex_9)) ≈ [20.0]
 
 # Example 11
 A = [-2 -6 3 -7 6;
@@ -93,21 +93,21 @@ D = [0 0;
      0 0;
      0 0]
 ex_11 = ss(A, B, C, D)
-@test tzero(ex_11) ≈ [4.0, -3.0]
+@test tzeros(ex_11) ≈ [4.0, -3.0]
 
 # Test for multiple zeros, siso tf
 s = tf("s")
 sys = s*(s + 1)*(s^2 + 1)*(s - 3)/((s + 1)*(s + 4)*(s - 4))
-@test tzero(sys) ≈ [3.0, -1.0, im, -im, 0.0]
+@test tzeros(sys) ≈ [3.0, -1.0, im, -im, 0.0]
 
 ## POLE ##
-@test pole(sys) ≈ [4.0, -4.0, -1.0]
-@test pole([sys sys]) ≈ [4.0, -4.0, -1.0] # Issue #81
-@test pole(ex_11) ≈ eigvals(ex_11.A)
-@test pole([2/(s+1) 3/(s+2); 1/(s+1) 1/(s+1)]) ≈ [-1, -1, -2]
+@test poles(sys) ≈ [4.0, -4.0, -1.0]
+@test poles([sys sys]) ≈ [4.0, -4.0, -1.0] # Issue #81
+@test poles(ex_11) ≈ eigvals(ex_11.A)
+@test poles([2/(s+1) 3/(s+2); 1/(s+1) 1/(s+1)]) ≈ [-1, -1, -2]
 
 
-poles = [-3.383889568918823 + 0.000000000000000im
+known_poles = [-3.383889568918823 + 0.000000000000000im
                             -2.199935841931115 + 0.000000000000000im
                             -0.624778101910111 + 1.343371895589931im
                             -0.624778101910111 - 1.343371895589931im
@@ -117,13 +117,13 @@ approxin2(el,col) = any(el.≈col)
 # Compares the computed poles with the expected poles
 # TODO: Improve the test for testing equalifity of sets of complex numbers
 # i.e. simplify and handle doubles.
-@test all(approxin(p,poles) for p in pole(ex_8)) && all(approxin2(p,pole(ex_8)) for p in poles)
+@test all(approxin(p,known_poles) for p in poles(ex_8)) && all(approxin2(p,poles(ex_8)) for p in known_poles)
 
 ex_12 = ss(-3, 2, 1, 2)
-@test pole(ex_12) ≈ [-3]
+@test poles(ex_12) ≈ [-3]
 
 ex_13 = ss([-1 1; 0 -1], [0; 1], [1 0], 0)
-@test pole(ex_13) ≈ [-1, -1]
+@test poles(ex_13) ≈ [-1, -1]
 
 
 ## ZPKDATA ##
@@ -185,8 +185,8 @@ sys = s*(s + 1)*(s^2 + 1)*(s - 3)/((s + 1)*(s + 4)*(s - 4))
 
 # Example 5.5 from http://www.control.lth.se/media/Education/EngineeringProgram/FRTN10/2017/e05_both.pdf
 G = [1/(s+2) -1/(s+2); 1/(s+2) (s+1)/(s+2)]
-@test_broken length(pole(G)) == 1
-@test length(tzero(G)) == 1
+@test_broken length(poles(G)) == 1
+@test length(tzeros(G)) == 1
 @test_broken size(minreal(ss(G)).A) == (2,2)
 
 

--- a/test/test_complex.jl
+++ b/test/test_complex.jl
@@ -14,8 +14,8 @@ C_2 = zpk([-1+im], [], 1.0+1im)
 @test im*ss(1) == ss(im)
 
 
-@test pole(zpk([], [-1+im,-1+im,0], 2.0im)) == [-1+im,-1+im,0]
-@test tzero(zpk([-1+im,-1+im,0], [-2], 2.0im)) == [-1+im,-1+im,0]
+@test poles(zpk([], [-1+im,-1+im,0], 2.0im)) == [-1+im,-1+im,0]
+@test tzeros(zpk([-1+im,-1+im,0], [-2], 2.0im)) == [-1+im,-1+im,0]
 
 @test zpk( tf([1.0, 1+im], [1.0, 2+im]) ) == zpk( [-1-im], [-2-im], 1.0+0im)
 
@@ -33,10 +33,10 @@ C_2 = zpk([-1+im], [], 1.0+1im)
 @test 1 / ( tf("s") + 1 + im ) == tf([1], [1, 1+im])
 
 s = tf("s");
-@test tzero(ss(-1, 1, 1, 1.0im)) ≈ [-1.0 + im] rtol=1e-15
-@test tzero(ss([-1.0-im 1-im; 2 0], [2; 0], [-1+1im -0.5-1.25im], 1)) ≈ [-1-2im, 2-im]
+@test tzeros(ss(-1, 1, 1, 1.0im)) ≈ [-1.0 + im] rtol=1e-15
+@test tzeros(ss([-1.0-im 1-im; 2 0], [2; 0], [-1+1im -0.5-1.25im], 1)) ≈ [-1-2im, 2-im]
 
-@test tzero(ss((s-2.0-1.5im)^3/(s+1+im)/(s+2)^3)) ≈ fill(2.0 + 1.5im, 3) rtol=1e-4
-@test tzero(ss((s-2.0-1.5im)*(s-3.0)/(s+1+im)/(s+2)^2)) ≈ [3.0, 2.0 + 1.5im] rtol=1e-14
+@test tzeros(ss((s-2.0-1.5im)^3/(s+1+im)/(s+2)^3)) ≈ fill(2.0 + 1.5im, 3) rtol=1e-4
+@test tzeros(ss((s-2.0-1.5im)*(s-3.0)/(s+1+im)/(s+2)^2)) ≈ [3.0, 2.0 + 1.5im] rtol=1e-14
 
 end

--- a/test/test_conversion.jl
+++ b/test/test_conversion.jl
@@ -61,7 +61,7 @@ sys2 = convert(TransferFunction, sys)
 w = 10.0 .^ (-2:2:50)
 @test freqresp(sys, w) ≈ freqresp(sys2, w)
 csort = v -> sort(v, lt = (x,y) -> abs(x) < abs(y))
-@test csort(pole(zpk(sys2))) ≈ [1+im, -2.0-3im]
+@test csort(poles(zpk(sys2))) ≈ [1+im, -2.0-3im]
 
 # Test complex 2
 sys4 = ss([-1.0+im 0;1 1],[1;0],[1 im],im)

--- a/test/test_discrete.jl
+++ b/test/test_discrete.jl
@@ -140,11 +140,11 @@ Gcl = tf(conv(B,T),zpconv(A,R,B,S)) # Form the closed loop polynomial from refer
 
 @test ControlSystems.isstable(Gcl)
 
-p = pole(Gcl)
+p = poles(Gcl)
 # Test that all desired poles are in the closed-loop system
-@test norm(minimum(abs.((pole(tf(Bm,Am)) .- sort(p, by=imag)')), dims=2)) < 1e-6
+@test norm(minimum(abs.((poles(tf(Bm,Am)) .- sort(p, by=imag)')), dims=2)) < 1e-6
 # Test that the observer poles are in the closed-loop system
-@test norm(minimum(abs.((pole(tf(1,Ao)) .- sort(p, by=imag)')), dims=2)) < 1e-6
+@test norm(minimum(abs.((poles(tf(1,Ao)) .- sort(p, by=imag)')), dims=2)) < 1e-6
 
 
 end

--- a/test/test_matrix_comps.jl
+++ b/test/test_matrix_comps.jl
@@ -8,7 +8,7 @@ sysr, G = balreal(sys)
 
 @test gram(sysr, :c) ≈ G
 @test gram(sysr, :o) ≈ G
-@test sort(pole(sysr)) ≈ sort(pole(sys))
+@test sort(poles(sysr)) ≈ sort(poles(sys))
 
 sysb,T = ControlSystems.balance_statespace(sys)
 Ab,Bb,Cb,T = ControlSystems.balance_statespace(A,B,C)
@@ -124,7 +124,7 @@ K = kalman(sys, R1, R2)
 cont = observer_controller(sys, L, K)
 syscl = feedback(sys, cont)
 
-pcl = pole(syscl)
+pcl = poles(syscl)
 A,B,C,D = ssdata(sys)
 allpoles = [
     eigvals(A-B*L)

--- a/test/test_pid_design.jl
+++ b/test/test_pid_design.jl
@@ -25,7 +25,7 @@ _,_,_,pm = margin(P*C)
 
 P = tf(1,[1, 1])
 piparams,C = placePI(P, 2, 0.7)
-@test pole(feedback(P, C)) ≈ [-1.4 + √2.04im, -1.4 - √2.04im]
+@test poles(feedback(P, C)) ≈ [-1.4 + √2.04im, -1.4 - √2.04im]
 @test [piparams[:Kp], piparams[:Ti]] ≈ [9/5, 9/20]
 
 end

--- a/test/test_simplification.jl
+++ b/test/test_simplification.jl
@@ -39,7 +39,7 @@ sysmin = minreal(sys)
 
 @test_broken balreal(sys-sysmin)
 
-@test all(sigma(sys-sysmin, [0.0, 1.0, 2.0])[1] .< 1e-15)  # Previously crashed because of zero dimensions in tzero
+@test all(sigma(sys-sysmin, [0.0, 1.0, 2.0])[1] .< 1e-15)  # Previously crashed because of zero dimensions in tzeros
 
 t = 0:0.1:10
 y1,x1 = step(sys,t)[[1,3]]

--- a/test/test_synthesis.jl
+++ b/test/test_synthesis.jl
@@ -15,7 +15,7 @@ T = [1]
 @test isapprox(numpoly(minreal(feedback(L),1e-5))[1].coeffs, numpoly(tf(1,[1,1]))[1].coeffs)# This test is ugly, but numerical stability is poor for minreal
 @test feedback2dof(B,A,R,S,T) == tf(B.*T, conv(A,R) + [0;0;conv(B,S)])
 @test feedback2dof(P,R,S,T) == tf(B.*T, conv(A,R) + [0;0;conv(B,S)])
-@test isapprox(pole(minreal(tf(feedback(Lsys)),1e-5)) , pole(minreal(feedback(L),1e-5)), atol=1e-5)
+@test isapprox(poles(minreal(tf(feedback(Lsys)),1e-5)) , poles(minreal(feedback(L),1e-5)), atol=1e-5)
 
 Pint = tf(1,[1,1])
 Cint = tf([1,1],[1,0])
@@ -23,7 +23,7 @@ Lint = P*C
 
 @test isapprox(minreal(feedback(Pint,Cint),1e-5), tf([1,0],[1,2,1]), rtol = 1e-5) # TODO consider keeping minreal of Int system Int
 @test isapprox(numpoly(minreal(feedback(Lint),1e-5))[1].coeffs, numpoly(tf(1,[1,1]))[1].coeffs)# This test is ugly, but numerical stability is poor for minreal
-@test isapprox(pole(minreal(tf(feedback(Lsys)),1e-5)) , pole(minreal(feedback(L),1e-5)), atol=1e-5)
+@test isapprox(poles(minreal(tf(feedback(Lsys)),1e-5)) , poles(minreal(feedback(L),1e-5)), atol=1e-5)
 
 @test feedback(ss(1),ss(1)) == ss(0.5)
 @test_throws ErrorException feedback(ss([1 0; 0 1], ones(2,2), ones(1,2),0))


### PR DESCRIPTION
Deprecate `pole, tzero` in favor of `poles tzeros`