### PR TITLE
usability improvements for multiplication with scalars

### DIFF
--- a/src/types/promotion.jl
+++ b/src/types/promotion.jl
@@ -67,5 +67,10 @@ Base.promote_rule(::Type{TransferFunction{TE, SisoRational{T1}}}, ::Type{MT}) wh
 Base.promote_rule(::Type{StateSpace{TE, T1}}, ::Type{MT}) where {TE, T1, MT<:AbstractMatrix} =
     StateSpace{TE, promote_type(T1,eltype(MT))}
 
+function Base.promote_rule(::Type{HeteroStateSpace{TE, T1, T2, T3, T4}}, ::Type{MT}) where {TE, T1, T2, T3, T4, MT<:AbstractMatrix}
+    T = promote_type(eltype(T2),eltype(T3),eltype(T4),eltype(MT))
+    StateSpace{TE, T} # We can't know how MT will interact with the hss, so we fall back to standard ss
+end
+
 Base.promote_rule(::Type{DelayLtiSystem{T1,S}}, ::Type{MT}) where {T1, S, MT<:AbstractMatrix} =
     DelayLtiSystem{promote_type(T1, eltype(MT)),S}

--- a/test/test_statespace.jl
+++ b/test/test_statespace.jl
@@ -61,7 +61,6 @@
         @test D_111 - D_211 == SS([-0.5 0 0; 0 0.2 -0.8; 0 -0.8 0.07],[2; 1; 2],
         [3 -1 -0],[0], 0.005)
 
-
         # Multiplication
         @test C_111 * C_221 == SS([-5 2 0; 0 -5 -3; 0 2 -9],
         [0 0; 1 0; 0 2],[3 0 0],[0 0])
@@ -70,6 +69,9 @@
         @test 4*C_222 == SS([-5 -3; 2 -9],[1 0; 0 2],[4 0; 0 4],[0 0; 0 0])
         @test D_111 * D_221 == SS([-0.5 2 0; 0 0.2 -0.8; 0 -0.8 0.07],
         [0 0; 1 0; 0 2],[3 0 0],[0 0],0.005)
+        @test C_111 * I(2) == I(2) * C_111 == SS(diagm([a_1; a_1]), 2*I(2), 3*I(2), 0*I(2))
+        @test minreal(C_111*C_222_d - C_222_d*C_111, atol=1e-3) == ss(0*I(2)) # scalar times MIMO
+        @test C_111*C_222 == ss([-5 0 2 0; 0 -5 0 2; 0 0 -5 -3; 0 0 2 -9], [0 0; 0 0; 1 0; 0 2], [3 0 0 0; 0 3 0 0], 0)
 
         # Division
         @test 1/C_222_d == SS([-6 -3; 2 -11],[1 0; 0 2],[-1 0; -0 -1],[1 -0; 0 1])
@@ -121,7 +123,6 @@
     # Errors
         @test_throws ErrorException C_111 + C_222             # Dimension mismatch
         @test_throws ErrorException C_111 - C_222             # Dimension mismatch
-        @test_throws ErrorException C_111 * C_222             # Dimension mismatch
         @test_throws ErrorException D_111 + C_111             # Sampling time mismatch
         @test_throws ErrorException D_111 - C_111             # Sampling time mismatch
         @test_throws ErrorException D_111 * C_111             # Sampling time mismatch


### PR DESCRIPTION
I've verified that this aligns with how multiplication works in matlab, in particular
```julia
@test_throws ErrorException C_111 * C_222
```
is now replaced by
```julia
@test C_111*C_222 == ss([-5 0 2 0; 0 -5 0 2; 0 0 -5 -3; 0 0 2 -9], [0 0; 0 0; 1 0; 0 2], [3 0 0 0; 0 3 0 0], 0)
```
which is the same result as matlab returns.
This allows, e.g.,
```julia
P*I(2) # for 1x1 P
```
which makes systems much easier to work with.

Here's also a fallback for HeteroStateSpace that makes it convert to a regular statespace if it's promoted with a matrix without knowing how the matrix is to be used later.