### PR TITLE
(actually) use hessenberg factorization for statespace freqresp

### DIFF
--- a/test/test_delayed_systems.jl
+++ b/test/test_delayed_systems.jl
@@ -109,7 +109,7 @@ d = exp(-2*s)
 # Test for internal function delayd_ss
 @test freqresp(ControlSystems.delayd_ss(1.0, 0.2), Ω)[:] ≈ exp.(-im*Ω) atol=1e-14
 @test freqresp(ControlSystems.delayd_ss(3.2, 0.4), Ω)[:] ≈ exp.(-3.2*im*Ω) atol=1e-14
-@test_throws ErrorException freqresp(ControlSystems.delayd_ss(3.2, 0.5), Ω)
+@test_throws ErrorException ControlSystems.delayd_ss(3.2, 0.5)
 
 # Simple tests for c2d of DelayLtiSystems
 @test freqresp(c2d(feedback(ss(0,1,1,0), delay(1.5)), 0.5), Ω) ≈ [0.5/((z - 1) + 0.5*z^-3) for z in exp.(im*Ω*0.5)]

--- a/test/test_freqresp.jl
+++ b/test/test_freqresp.jl
@@ -116,3 +116,34 @@ mag, mag, ws2 = bode(sys2)
 @test minimum(ws2) <= 0.2min(p,z)
 @test length(ws2) > 100
 end
+
+
+## Benchmark code for freqresp
+# sizes = [1:40; 50:5:100; 120:20:300; 800]
+# times1 = map(sizes) do nx
+#     w = exp10.(LinRange(-2, 2, 200))
+#     @show nx
+#     G = ssrand(2,2,nx)
+#     nx == 1 && (freqresp(G, w)) # precompile
+#     GC.gc()
+#     t = @timed freqresp(G, w)
+#     (t.time, t.bytes)
+# end
+# sleep(5)
+# times2 = map(sizes) do nx
+#     w = exp10.(LinRange(-2, 2, 200))
+#     @show nx
+#     G = ssrand(2,2,nx)
+#     # NOTE: rename the freqresp method to be benchmarked before running. Below it's called freqresp_large
+#     nx == 1 && (freqresp_large(G, w)) # precompile
+#     GC.gc()
+#     t = @timed freqresp_large(G, w)
+#     (t.time, t.bytes)
+# end
+
+# f1 = plot(sizes, first.(times1), scale=:log10, lab="Time freqresp", m=:o)
+# plot!(sizes, first.(times2), scale=:log10, lab="Time freqresp_large", xlabel="Model order", m=:o)
+
+# f2 = plot(sizes, last.(times1), scale=:log10, lab="Allocations freqresp", m=:o)
+# plot!(sizes, last.(times2), scale=:log10, lab="Allocations freqresp_large", xlabel="Model order", m=:o)
+# plot(f1, f2)


### PR DESCRIPTION
The benchmarks show it's quite a lot faster than the previous `freqresp`. The new version is labelled "large" because I had originally intended to use it for large systems only, but it turned out to be faster across the board. The benchmark is performed on a 2x2 system with varying order of the state, evaluating the freqresp on 200 frequency points.
![plot_45](https://user-images.githubusercontent.com/3797491/149091084-ae1e18d2-0749-40c3-9cef-e7b32833daa3.png)
