### PR TITLE
fallback freqresp for matrices without hessenberg

### DIFF
--- a/src/freqresp.jl
+++ b/src/freqresp.jl
@@ -26,13 +26,20 @@ end
 _freq(w, ::Continuous) = complex(0, w)
 _freq(w, te::Discrete) = cis(w*te.Ts)
 
-function freqresp(sys::AbstractStateSpace, w_vec::AbstractVector{W}) where W <: Real
+@autovec () function freqresp(sys::AbstractStateSpace, w_vec::AbstractVector{W}) where W <: Real
     ny, nu = size(sys)
     T = promote_type(Complex{real(eltype(sys.A))}, Complex{W})
     if sys.nx == 0 # Only D-matrix
         return PermutedDimsArray(repeat(T.(sys.D), 1, 1, length(w_vec)), (3,1,2))
     end
-    F = hessenberg(sys.A)
+    local F
+    try
+        F = hessenberg(sys.A)
+    catch e
+        # For matrix types that do not have a hessenberg implementation, we call the standard version of freqresp.
+        e isa MethodError && return freqresp_nohess(sys, w_vec)
+        rethrow()
+    end
     Q = Matrix(F.Q)
     A = F.H
     C = sys.C*Q
@@ -49,6 +56,38 @@ function freqresp(sys::AbstractStateSpace, w_vec::AbstractVector{W}) where W <: 
         copyto!(Bc,B) # initialize storage to B
         w = -_freq(w_vec[i], te)
         ldiv!(A, Bc, shift = w) # B += (A - w*I)\B # solve (A-wI)X = B, storing result in B
+        mul!(Ri, C, Bc, -1, 1) # use of 5-arg mul to subtract from D already in Ri. - rather than + since (A - w*I) instead of (w*I - A)
+    end
+    PermutedDimsArray(R, (3,1,2)) # PermutedDimsArray doesn't allocate to perform the permutation
+end
+
+"""
+    freqresp_nohess(sys::AbstractStateSpace, w_vec::AbstractVector{<:Real})
+
+Compute the frequency response of `sys` without forming a Hessenberg factorization.
+This function is called automatically if the Hessenberg factorization fails.
+"""
+freqresp_nohess
+@autovec () function freqresp_nohess(sys::AbstractStateSpace, w_vec::AbstractVector{W}) where W <: Real
+    ny, nu = size(sys)
+    nx = sys.nx
+    T = promote_type(Complex{real(eltype(sys.A))}, Complex{W})
+    if nx == 0 # Only D-matrix
+        return PermutedDimsArray(repeat(T.(sys.D), 1, 1, length(w_vec)), (3,1,2))
+    end
+    A,B,C,D = ssdata(sys)
+    te = sys.timeevol
+    R = Array{T, 3}(undef, ny, nu, length(w_vec))
+    Ac = (A+one(T)*I) # for storage
+    Adiag = diagind(A)
+    for i in eachindex(w_vec)
+        Ri = @views R[:,:,i]
+        copyto!(Ri,D) # start with the D-matrix
+        isinf(w_vec[i]) && continue
+        w = _freq(w_vec[i], te)
+        @views copyto!(Ac[Adiag],A[Adiag]) # reset storage to A
+        @views Ac[Adiag] .-= w # Ac = A - w*I
+        Bc = Ac \ B # Bc = (A - w*I)\B # avoid inplace to handle sparse matrices etc.
         mul!(Ri, C, Bc, -1, 1) # use of 5-arg mul to subtract from D already in Ri. - rather than + since (A - w*I) instead of (w*I - A)
     end
     PermutedDimsArray(R, (3,1,2)) # PermutedDimsArray doesn't allocate to perform the permutation

--- a/test/test_freqresp.jl
+++ b/test/test_freqresp.jl
@@ -20,6 +20,7 @@ G = ss([-5 0 0 0; 0 -1 -2.5 0; 0 4 0 0; 0 0 0 -6], [2 0; 0 1; 0 0; 0 2],
 w = exp10.(range(-1, stop=1, length=50))
 
 sys1 = ss(1)
+sys1s = HeteroStateSpace(sparse([1]))
 G1 = tf(1)
 H1 = zpk(1)
 resp1 = ones(ComplexF64, length(w), 1, 1)
@@ -29,12 +30,14 @@ resp1 = ones(ComplexF64, length(w), 1, 1)
 @test evalfr(H1, im*w[1]) == fill(resp1[1], 1, 1)
 
 @test freqresp(sys1, w) == resp1
+@test freqresp(sys1s, w) == resp1
 @test freqresp(G1, w) == resp1
 @test freqresp(H1, w) == resp1
 
 ## First order system
 
 sys2 = ss(-1, 1, 1, 1)
+sys2s = HeteroStateSpace(sparse([-1;;]),sparse([1;;]),sparse([1;;]),sparse([1;;])) # test that freqresp works for matrix types that don't support hessenberg
 G2 = tf([1, 2], [1,1])
 H2 = zpk([-2], [-1.0], 1.0)
 resp2 = reshape((im*w .+ 2)./(im*w  .+ 1), length(w), 1, 1)
@@ -44,6 +47,7 @@ resp2 = reshape((im*w .+ 2)./(im*w  .+ 1), length(w), 1, 1)
 @test evalfr(H2, im*w[1]) == fill(resp2[1], 1, 1)
 
 @test freqresp(sys2, w) ≈ resp2 rtol=1e-15
+@test freqresp(sys2s, w) ≈ resp2 rtol=1e-15
 @test freqresp(G2, w) == resp2
 @test freqresp(H2, w) == resp2
 


### PR DESCRIPTION
The old `freqresp` could technically be used for this, but it's terribly slow for MIMO systems and the extra function is thus warranted