### PR TITLE
Add tfdata function

### DIFF
--- a/src/ControlSystems.jl
+++ b/src/ControlSystems.jl
@@ -95,7 +95,8 @@ export  LTISystem,
         denpoly,
         iscontinuous,
         isdiscrete,
-        ssdata
+        ssdata,
+        tfdata
 
 
 # QUESTION: are these used? LaTeXStrings, Requires, IterTools

--- a/src/types/TransferFunction.jl
+++ b/src/types/TransferFunction.jl
@@ -208,3 +208,12 @@ function Base.show(io::IO, G::TransferFunction)
         print(io, "\nStatic gain transfer function model")
     end
 end
+
+
+# Getter functions ##########
+
+"""
+    `num, den = tfdata(sys)`
+Get the numerator and denominator of the transfer function.
+"""
+tfdata(sys::TransferFunction) = reverse(numpoly(sys)[1].coeffs), reverse(denpoly(sys)[1].coeffs)


### PR DESCRIPTION
In Matlab, there is ```tfdata``` to get the numerator and denumerator of a transfer function, so I add the same ```tfdata``` to ControlSystems.jl. If it is ok, I will add tests and docs for this method.