### PR TITLE
Fixed missing tic in docstring

### DIFF
--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -85,7 +85,7 @@ The result structure contains the fields `y, t, x, u` and can be destructured au
 ```julia
 y, t, x, u = result
 ```
-`y, `x`, `u` have time in the second dimension. Initial state `x0` defaults to zero.
+`y`, `x`, `u` have time in the second dimension. Initial state `x0` defaults to zero.
 
 Continuous time systems are simulated using an ODE solver if `u` is a function. If `u` is an array, the system is discretized (with `method=:zoh` by default) before simulation. For a lower level inteface, see `?Simulator` and `?solve`
 


### PR DESCRIPTION
Sorry if this is too minor issue to really deserve a pr, but it makes the docstring print in a funky way in the REPL.