### PR TITLE
`hinfnorm`: early exit for cases where norm is 0

### DIFF
--- a/src/matrix_comps.jl
+++ b/src/matrix_comps.jl
@@ -309,7 +309,7 @@ function _infnorm_two_steps_ct(sys::AbstractStateSpace, normtype::Symbol, tol=1e
                          opnorm(evalfr(sys, im*m_vec_init[2]));
                          opnorm(sys.D)])
     ω_peak = m_vec_init[idx]
-
+    lb == 0 && (return zero(T), zero(T))
     # Iterations
     for iter=1:maxIters
         gamma = (1+2*T(tol))*lb


### PR DESCRIPTION
avoids singularity exception a few lines below

corresponds to
https://github.com/andreasvarga/DescriptorSystems.jl/blob/353b3467f53d82585397b5cb5a909bca9b5e6e3b/src/analysis.jl#L827