### PR TITLE
remove `prescale`

### DIFF
--- a/src/matrix_comps.jl
+++ b/src/matrix_comps.jl
@@ -592,27 +592,6 @@ function similarity_transform(sys::ST, T) where ST <: AbstractStateSpace
     ST(A,B,C,D,sys.timeevol)
 end
 
-"""
-    syst, S = prescale(sys)
-Perform a eigendecomposition on system state-transition matrix `sys.A`.
-```
-Ã = S⁻¹AS
-B̃ = S⁻¹ B
-C̃ = CS
-D̃ = D
-```
-Such that `Ã` is diagonal.
-Returns a new scaled state-space object and the associated transformation
-matrix.
-"""
-function prescale(sys::AbstractStateSpace)
-    d, S = eigen(sys.A)
-    A = Diagonal(d)
-    B = S\sys.B
-    C = sys.C*S
-    normalized_sys = iscontinuous(sys) ? ss(A, B, C, sys.D) : ss(A, B, C, sys.D, sys.Ts)
-    return normalized_sys, S
-end
 
 """
     sysi = innovation_form(sys, R1, R2)

--- a/test/test_matrix_comps.jl
+++ b/test/test_matrix_comps.jl
@@ -71,11 +71,6 @@ syst = similarity_transform(sys, Tr)
 @test sys.B ≈ Tr*syst.B
 @test sys.C*Tr ≈ syst.C
 
-nsys, T = prescale(sys)
-@test isdiag(nsys.A)
-@test T*nsys.A ≈ sys.A*T
-@test T*nsys.B ≈ sys.B
-@test nsys.C ≈ sys.C*T
 
 sys = ss([1 0.1; 0 1], ones(2), [1. 0], 0)
 sysi = ControlSystems.innovation_form(sys, I, I)


### PR DESCRIPTION
The computation tested in  #465 gives identical result to `balance_statespace`, I assume the functions are (or close to) identical.

Closes #614 