### PR TITLE
Fix some problems for comparisons between tfs

### DIFF
--- a/src/types/SisoTfTypes/SisoRational.jl
+++ b/src/types/SisoTfTypes/SisoRational.jl
@@ -101,9 +101,16 @@ function isapprox(f1::SisoRational, f2::SisoRational; rtol::Real=sqrt(eps()), at
     # Get representation of num/den so index access is correct
     f1num, f1den = numvec(f1), denvec(f1)
     f2num, f2den = numvec(f2), denvec(f2)
-    _prefill_zero(x, n) = [zeros(n - length(x)); x]
-    f1num, f2num = _prefill_zero.((f1num, f2num), maximum(length.((f1num, f2num))))
-    f1den, f2den = _prefill_zero.((f1den, f2den), maximum(length.((f1den, f2den))))
+    if length(f1num) < length(f2num)
+        f1num = [zeros(length(f2num) - length(f1num)); f1num]
+    elseif length(f2num) < length(f1num)
+        f2num = [zeros(length(f1num) - length(f2num)); f2num]
+    end
+    if length(f1den) < length(f2den)
+        f1den = [zeros(length(f2den) - length(f1den)); f1den]
+    elseif length(f2den) < length(f1den)
+        f2den = [zeros(length(f1den) - length(f2den)); f2den]
+    end
     isapprox(f1num * f2den[1], f2num * f1den[1], rtol=rtol, atol=atol) && isapprox(f1den * f2den[1], f2den * f1den[1], rtol=rtol, atol=atol)
 end
 

--- a/src/types/SisoTfTypes/SisoRational.jl
+++ b/src/types/SisoTfTypes/SisoRational.jl
@@ -101,6 +101,9 @@ function isapprox(f1::SisoRational, f2::SisoRational; rtol::Real=sqrt(eps()), at
     # Get representation of num/den so index access is correct
     f1num, f1den = numvec(f1), denvec(f1)
     f2num, f2den = numvec(f2), denvec(f2)
+    _prefill_zero(x, n) = [zeros(n - length(x)); x]
+    f1num, f2num = _prefill_zero.((f1num, f2num), maximum(length.((f1num, f2num))))
+    f1den, f2den = _prefill_zero.((f1den, f2den), maximum(length.((f1den, f2den))))
     isapprox(f1num * f2den[1], f2num * f1den[1], rtol=rtol, atol=atol) && isapprox(f1den * f2den[1], f2den * f1den[1], rtol=rtol, atol=atol)
 end
 

--- a/src/types/SisoTfTypes/SisoRational.jl
+++ b/src/types/SisoTfTypes/SisoRational.jl
@@ -89,11 +89,19 @@ function evalfr(f::SisoRational{T}, s::Number) where T
     end
 end
 
-==(f1::SisoRational, f2::SisoRational) = (f1.num * f2.den[1] == f2.num * f1.den[1] && f1.den * f2.den[1] == f2.den * f1.den[1]) # NOTE: Not in analogy with how it's done for SisoZpk
+function ==(f1::SisoRational, f2::SisoRational)
+    # Get representation of num/den so index access is correct
+    f1num, f1den = numvec(f1), denvec(f1)
+    f2num, f2den = numvec(f2), denvec(f2)
+    (f1num * f2den[1] == f2num * f1den[1] && f1den * f2den[1] == f2den * f1den[1]) # NOTE: Not in analogy with how it's done for SisoZpk
+end
 
 # We might want to consider alowing scaled num and den as equal
 function isapprox(f1::SisoRational, f2::SisoRational; rtol::Real=sqrt(eps()), atol::Real=0)
-    isapprox(f1.num * f2.den[1], f2.num * f1.den[1], rtol=rtol, atol=atol) && isapprox(f1.den * f2.den[1], f2.den * f1.den[1], rtol=rtol, atol=atol)
+    # Get representation of num/den so index access is correct
+    f1num, f1den = numvec(f1), denvec(f1)
+    f2num, f2den = numvec(f2), denvec(f2)
+    isapprox(f1num * f2den[1], f2num * f1den[1], rtol=rtol, atol=atol) && isapprox(f1den * f2den[1], f2den * f1den[1], rtol=rtol, atol=atol)
 end
 
 +(f1::SisoRational, f2::SisoRational) = SisoRational(f1.num*f2.den + f2.num*f1.den, f1.den*f2.den)

--- a/test/test_transferfunction.jl
+++ b/test/test_transferfunction.jl
@@ -37,6 +37,11 @@ z = tf("z", 0.005)
 @test tf([1.0], [2.0,3.0]) == tf(π*[1.0], π*[2.0,3.0])
 @test tf([1.0+2.0im], [2.0+im,3.0]) == tf((π+im)*[1+2.0im], (π+im)*[2.0+im,3.0])
 
+# Test inequality
+@test tf([1], [1]) != tf([2], [1])
+@test tf([1.0], [1.0,0.0]) != tf([1.0], [2.0,0.0])
+@test tf([1.0+2.0im], [2.0+im,3.0]) != tf([1+2.0im], [1.0+im,3.0])
+
 # Test approximate equlity
 # rtol should just be on the order of ϵ, no particular reason that exactly ϵ
 # would work, but apparently it does


### PR DESCRIPTION
The tests added here would have returned incorrectly before, thanks to incorrect indexing into the polynomials.

Fix indexing, add tests for the previous error and fix new test error that was previously hidden by allowing approximate comparison between polynomials of different sizes.