### PR TITLE
balance tf -> ss by default

### DIFF
--- a/src/types/conversion.jl
+++ b/src/types/conversion.jl
@@ -83,7 +83,8 @@ function Base.convert(::Type{StateSpace}, G::TransferFunction{TE,<:SisoTf{T0}}; 
     convert(StateSpace{TE,T}, G; kwargs...)
 end
 
-function Base.convert(::Type{StateSpace{TE,T}}, G::TransferFunction; balance=false) where {TE,T<:Number}
+# Note: balancing is only applied by default for floating point types, integer systems are not balanced since that would change the type. 
+function Base.convert(::Type{StateSpace{TE,T}}, G::TransferFunction; balance=!(T <: Integer)) where {TE,T<:Number}
     if !isproper(G)
         error("System is improper, a state-space representation is impossible")
     end
@@ -114,7 +115,7 @@ function Base.convert(::Type{StateSpace{TE,T}}, G::TransferFunction; balance=fal
         end
     end
     if balance
-        A, B, C = balance_statespace(A, B, C)[1:3] 
+        A, B, C = balance_statespace(A, B, C)
     end
     return StateSpace{TE,T}(A, B, C, D, TE(G.timeevol))
 end

--- a/test/test_connections.jl
+++ b/test/test_connections.jl
@@ -93,12 +93,12 @@ s = tf("s")
 
     
 # Combination tf and ss
-@test [C_111 Ctf_221] == [C_111 ss(Ctf_221)]
-@test [C_111; Ctf_212] == [C_111; ss(Ctf_212)]
-@test append(C_111, Ctf_211) == append(C_111, ss(Ctf_211))
-@test [D_111 Dtf_221] == [D_111 ss(Dtf_221)]
-@test [D_111; Dtf_212] == [D_111; ss(Dtf_212)]
-@test append(D_111, Dtf_211) == append(D_111, ss(Dtf_211))
+@test [C_111 Ctf_221] == [C_111 convert(StateSpace, Ctf_221, balance=false)]
+@test [C_111; Ctf_212] == [C_111; convert(StateSpace, Ctf_212, balance=false)]
+@test append(C_111, Ctf_211) == append(C_111, convert(StateSpace, Ctf_211, balance=false))
+@test [D_111 Dtf_221] == [D_111 convert(StateSpace, Dtf_221, balance=false)]
+@test [D_111; Dtf_212] == [D_111; convert(StateSpace, Dtf_212, balance=false)]
+@test append(D_111, Dtf_211) == append(D_111, convert(StateSpace, Dtf_211, balance=false))
 
 # Combination of DelayLtiSystem with TransferFunction and StateSpace
 @test [delay(1.0) tf(1, [1,2])] == [delay(1.0) ss(-2.0,1,1,0)]


### PR DESCRIPTION
Avoinds many problems of porrly conditioned numerics

Closes #419 (I tried the simulation as well and it was no problem with this PR)