### PR TITLE
Fix occasional problems with `solve` not including endpoint

### DIFF
--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -196,7 +196,7 @@ function lsim(sys::AbstractStateSpace, u::Function, t::AbstractVector;
         x,uout = ltitr(simsys.A, simsys.B, u, t, T.(x0))
     else
         p = (sys.A, sys.B, u)
-        sol = solve(ODEProblem(f_lsim, x0, (t[1], t[end]), p), alg; saveat=t, kwargs...)
+        sol = solve(ODEProblem(f_lsim, x0, (t[1], t[end]+dt/2), p), alg; saveat=t, kwargs...)
         x = reduce(hcat, sol.u)
         uout = reduce(hcat, u(x[:, i], t[i]) for i in eachindex(t))
         simsys = sys

--- a/test/test_plots.jl
+++ b/test/test_plots.jl
@@ -24,7 +24,7 @@ function getexamples()
     impulsegen() = plot(impulse(sys, ts[end]), l=:blue)
     L = lqr(sysss.A, sysss.B, [1 0; 0 1], [1 0; 0 1])
     lsimgen() = plot(lsim(sysss, (x,i)->-L*x, ts; x0=[1;2]), plotu=true)
-    plot(lsim.([sysss, sysss], (x,i)->-L*x, Ref(ts); x0=[1;2]), plotu=true)
+    plot(lsim.([sysss, sysss], (x,i)->-L*x, Ref(ts); x0=[1;2]), plotu=true, plotx=true)
 
     margingen() = marginplot([tf1, tf2], ws)
     gangoffourgen() = begin


### PR DESCRIPTION
Due to numerical rounding issues, `OrdinaryDiffEq.solve` sometimes fails to include the last time point and then `lsim` fails due to trying to access the solution out of bounds. This PR extends the time range by half a sample time to make sure the last time point is available.

This PR also adds an option to plot the states when plotting a `SimResult`