### PR TITLE
reduce allocations in freqresp

### DIFF
--- a/src/freqresp.jl
+++ b/src/freqresp.jl
@@ -75,7 +75,8 @@ end
         Q = Matrix(F.Q)
     catch e
         # For matrix types that do not have a hessenberg implementation, we call the standard version of freqresp.
-        e isa MethodError && return freqresp_nohess!(R, sys, w_vec)
+        e isa Union{MethodError, ErrorException} && return freqresp_nohess!(R, sys, w_vec)
+        # ErrorException appears if we try to access Q on a type which does not have Q as a field or property, notably HessenbergFactorization from GenericLinearAlgebra
         rethrow()
     end
     A = F.H

--- a/test/test_freqresp.jl
+++ b/test/test_freqresp.jl
@@ -66,6 +66,7 @@ resp2 = reshape((im*w .+ 2)./(im*w  .+ 1), length(w), 1, 1)
 @inferred freqresp(sys2s, w)
 @inferred freqresp(G2, w)
 @inferred freqresp(H2, w)
+@test @allocated freqresp(sys2, w) < 1.2*305551488 # allow 20% increase due to compiler variations
 
 
 ## Complex-coefficient system

--- a/test/test_freqresp.jl
+++ b/test/test_freqresp.jl
@@ -66,7 +66,7 @@ resp2 = reshape((im*w .+ 2)./(im*w  .+ 1), length(w), 1, 1)
 @inferred freqresp(sys2s, w)
 @inferred freqresp(G2, w)
 @inferred freqresp(H2, w)
-@test @allocated freqresp(sys2, w) < 1.2*305551488 # allow 20% increase due to compiler variations
+@test (@allocated freqresp(sys2, w)) < 1.2*56672 # allow 20% increase due to compiler variations
 
 
 ## Complex-coefficient system


### PR DESCRIPTION
Due to https://github.com/JuliaLang/julia/issues/44290 we incured a lot of allocations in `freqresp`

```julia
w = exp10.(LinRange(-2, 2, 50000))
G = ssrand(2,2,3)
R = freqresp(G, w).parent;
@btime ControlSystems.freqresp!($R, $G, $w);
114.359 ms (250013 allocations: 753.82 MiB) # before
11.532 ms (16 allocations: 35.33 KiB) # after
```
A solid 10x improvement in time and 21000x in memory :)