### PR TITLE
improve performance in freqresp for tf

### DIFF
--- a/test/test_freqresp.jl
+++ b/test/test_freqresp.jl
@@ -67,7 +67,7 @@ resp2 = reshape((im*w .+ 2)./(im*w  .+ 1), length(w), 1, 1)
 @inferred freqresp(G2, w)
 @inferred freqresp(H2, w)
 @test (@allocated freqresp(sys2, w)) < 1.2*56672 # allow 20% increase due to compiler variations
-
+@test (@allocated freqresp(G2, w)) < 1.2*976 # allow 20% increase due to compiler variations
 
 ## Complex-coefficient system
 sys3 = ss(-1+im, 1, (1-im), (1-im))


### PR DESCRIPTION
This adds a custom method for transfer functions that avoid the matrix allocations from `evalfr`. 
10x improvement in time for representable benchmark and 2000x in memory.
```julia
G = tf(1, [1, 1])
w = exp10.(LinRange(-2, 2, 200))
R = freqresp(G, w).parent
@btime ControlSystems.freqresp!($R, $G, $w);

julia> @btime ControlSystems.freqresp!($R, $G, $w);
  51.948 μs (2201 allocations: 146.94 KiB) # Before

julia> @btime ControlSystems.freqresp!($R, $G, $w);
  4.048 μs (1 allocation: 64 bytes)        # After
```

This PR also removes an extra specialization that was not needed.