### PR TITLE
reduce allocations and improve performance in sminreal

### DIFF
--- a/src/simplification.jl
+++ b/src/simplification.jl
@@ -44,10 +44,10 @@ function struct_ctrb_states(A::AbstractVecOrMat, B::AbstractVecOrMat)
     bitA = UInt16.(.!iszero.(A)) # Convert to Int because mutiplying with a bit matrix is slow
     x = vec(any(B .!= 0, dims=2)) # index vector indicating states that have been affected by input
     xi = bitA * x
-    @. x = x | !iszero(xi)
+    @. xi = xi | !iszero(xi)
     for i = 2:size(A, 1) # apply A nx times, similar to controllability matrix
-        mul!(xi, bitA, x)
-        x .= x .| .!iszero.(xi)
+        mul!(xi, bitA, xi)
+        @. xi = xi | !iszero(xi)
     end
-    x
+    xi .!= false # Convert back to BitVector
 end

--- a/src/simplification.jl
+++ b/src/simplification.jl
@@ -13,6 +13,7 @@ trunc_zero!(A) = A[abs.(A) .< 10eps(maximum(abs, A))] .= 0
 trunc_zero!(sys.A); trunc_zero!(sys.B); trunc_zero!(sys.C)
 sminreal(sys)
 ```
+See also [`minreal`](@ref)
 """
 function sminreal(sys::StateSpace)
     A, B, C, inds = struct_ctrb_obsv(sys)

--- a/src/simplification.jl
+++ b/src/simplification.jl
@@ -45,10 +45,11 @@ function struct_ctrb_states(A::AbstractVecOrMat, B::AbstractVecOrMat)
     bitA = UInt16.(.!iszero.(A)) # Convert to Int because mutiplying with a bit matrix is slow
     x = vec(any(B .!= 0, dims=2)) # index vector indicating states that have been affected by input
     xi = bitA * x
-    @. xi = xi | !iszero(xi)
+    xi2 = similar(xi)
+    @. xi = (xi != false) | !iszero(x)
     for i = 2:size(A, 1) # apply A nx times, similar to controllability matrix
-        mul!(xi, bitA, xi)
-        @. xi = xi | !iszero(xi)
+        mul!(xi2, bitA, xi)
+        @. xi = (xi2 != false) | !iszero(xi)
     end
     xi .!= false # Convert back to BitVector
 end

--- a/src/types/StateSpace.jl
+++ b/src/types/StateSpace.jl
@@ -389,6 +389,8 @@ end
 Minimal realisation algorithm from P. Van Dooreen, The generalized eigenstructure problem in linear system theory, IEEE Transactions on Automatic Control
 
 For information about the options, see `?ControlSystems.MatrixPencils.lsminreal`
+
+See also [`sminreal`](@ref), which is both numerically exact and substantially faster than `minreal`, but with a much more limited potential in removing non-minimal dynamics.
 """
 function minreal(sys::T, tol=nothing; fast=false, atol=0.0, kwargs...) where T <: AbstractStateSpace
     A,B,C,D = ssdata(sys)


### PR DESCRIPTION
```julia
julia> G.nx, G.ny, G.nu
(400, 10, 10)

julia> @btime ControlSystems.struct_ctrb_states($(G.A), $(G.B));
  45.817 ms (1615 allocations: 2.99 MiB) # before

julia> @btime ControlSystems.struct_ctrb_states($(G.A), $(G.B));
  1.584 ms (17 allocations: 322.88 KiB)
```