### PR TITLE
add precompilation

### DIFF
--- a/generate_precompile.jl
+++ b/generate_precompile.jl
@@ -1,0 +1,12 @@
+G1 = ssrand(1,1,1)
+G2 = tf(G1)
+G3 = ssrand(1,1,1,Ts=1)
+G4 = tf(G3)
+
+u = randn(1,5)
+w = exp10.(LinRange(-2, 2, 20))
+for G in (G1, G2, G3, G4)
+    isdiscrete(G) && lsim(G, u)
+    bode(G, w)
+    nyquist(G, w)
+end

--- a/src/ControlSystems.jl
+++ b/src/ControlSystems.jl
@@ -187,4 +187,8 @@ end
 # The path has to be evaluated upon initial import
 const __CONTROLSYSTEMS_SOURCE_DIR__ = dirname(Base.source_path())
 
+# if !(occursin(joinpath(".julia", "dev"), __CONTROLSYSTEMS_SOURCE_DIR__))
+    # Only precompile if the package is not checked out for development. Precompilation takes about 6 seconds, and saves about 2 seconds on the compilation script. For a user loading the same version of the package multiple times, precompilation makes the experience slightly more snappy. For a developer, paying the precompilation price each time the package has been modified is unlikely to be beneficial.
+    include("precompile.jl")
+# end
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,121 @@
+
+precompile(Tuple{ControlSystems.var"##ssrand#283", Bool, Bool, Nothing, typeof(ControlSystems.ssrand), Type, Int64, Int64, Int64})
+precompile(Tuple{typeof(Base.randn), Type{Float64}, Int64, Int64})
+precompile(Tuple{typeof(LinearAlgebra.eigvals), Array{Float64, 2}})
+precompile(Tuple{typeof(Base.real), Array{Float64, 1}})
+precompile(Tuple{typeof(Base.maximum), Array{Float64, 1}})
+precompile(Tuple{typeof(Base.max), Int64, Float64})
+precompile(Tuple{typeof(Base.:(*)), Float64, Float64})
+precompile(Tuple{typeof(Base.:(*)), Float64, LinearAlgebra.UniformScaling{Bool}})
+precompile(Tuple{typeof(Base.:(-)), Array{Float64, 2}, LinearAlgebra.UniformScaling{Float64}})
+precompile(Tuple{Type{ControlSystems.StateSpace{TE, T} where T where TE}, Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}})
+precompile(Tuple{Polynomials.var"##s10#10", Any, Any, Any, Any, Any, Any})
+precompile(Tuple{Base.Cartesian.var"#@nloops", LineNumberNode, Module, Any, Any, Any, Vararg{Any}})
+precompile(Tuple{typeof(Base.Cartesian._nloops), Int64, Symbol, Symbol, Expr})
+precompile(Tuple{Base.Cartesian.var"#@nref", LineNumberNode, Module, Int64, Symbol, Any})
+precompile(Tuple{typeof(ControlSystems.tf), ControlSystems.StateSpace{ControlSystems.Continuous, Float64}})
+precompile(Tuple{typeof(Base.vect), Float64, Vararg{Any}})
+precompile(Tuple{typeof(Base.copyto!), Array{Float64, 1}, Tuple{Float64, Int64}})
+precompile(Tuple{typeof(Base.:(-)), Polynomials.Polynomial{Float64, :x}, Polynomials.Polynomial{Float64, :x}})
+precompile(Tuple{typeof(Base.:(*)), Float64, Polynomials.Polynomial{Float64, :x}})
+precompile(Tuple{Type{NamedTuple{(:Ts,), T} where T<:Tuple}, Tuple{Int64}})
+precompile(Tuple{ControlSystems.var"#ssrand##kw", NamedTuple{(:Ts,), Tuple{Int64}}, typeof(ControlSystems.ssrand), Int64, Int64, Int64})
+precompile(Tuple{ControlSystems.var"##ssrand#283", Bool, Bool, Int64, typeof(ControlSystems.ssrand), Type, Int64, Int64, Int64})
+precompile(Tuple{typeof(Base.:(*)), Array{Float64, 2}, Float64})
+precompile(Tuple{typeof(Base.Broadcast.broadcasted), Function, Array{Float64, 1}})
+precompile(Tuple{Type{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Axes, F, Args} where Args<:Tuple where F where Axes}, typeof(Base.abs), Tuple{Array{Float64, 1}}})
+precompile(Tuple{typeof(Base.Broadcast.materialize), Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(Base.abs), Tuple{Array{Float64, 1}}}})
+precompile(Tuple{typeof(Base.:(/)), Array{Float64, 2}, Float64})
+precompile(Tuple{Type{ControlSystems.StateSpace{TE, T} where T where TE}, Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}, Int64})
+precompile(Tuple{typeof(ControlSystems.tf), ControlSystems.StateSpace{ControlSystems.Discrete{Int64}, Float64}})
+precompile(Tuple{typeof(Base.randn), Int64, Int64})
+precompile(Tuple{Type{Base.LinRange{T, L} where L<:Integer where T}, Int64, Int64, Int64})
+precompile(Tuple{typeof(Base.Broadcast.broadcasted), Function, Base.LinRange{Float64, Int64}})
+precompile(Tuple{typeof(Base.Broadcast.broadcasted), Base.Broadcast.DefaultArrayStyle{1}, Function, Base.LinRange{Float64, Int64}})
+precompile(Tuple{Type{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Axes, F, Args} where Args<:Tuple where F where Axes}, typeof(Base.exp10), Tuple{Base.LinRange{Float64, Int64}}})
+precompile(Tuple{typeof(Base.Broadcast.materialize), Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(Base.exp10), Tuple{Base.LinRange{Float64, Int64}}}})
+precompile(Tuple{typeof(ControlSystems.isdiscrete), ControlSystems.StateSpace{ControlSystems.Continuous, Float64}})
+precompile(Tuple{Base.var"##s859#792", Any, Any, Any, Any, Any})
+precompile(Tuple{Base.var"##s859#512", Any, Any, Any, Any, Any, Any})
+precompile(Tuple{typeof(ControlSystems.bode), ControlSystems.StateSpace{ControlSystems.Continuous, Float64}, Array{Float64, 1}})
+precompile(Tuple{Base.var"##s859#511", Any, Any, Any, Any, Any})
+precompile(Tuple{Base.var"#@_inline_meta", LineNumberNode, Module})
+precompile(Tuple{typeof(Base.getindex), Array{Float64, 3}, Int64, Base.UnitRange{Int64}, Base.UnitRange{Int64}})
+precompile(Tuple{typeof(Base.Broadcast.broadcasted), Function, Array{Float64, 2}, Base.Irrational{:π}})
+precompile(Tuple{Type{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{2}, Axes, F, Args} where Args<:Tuple where F where Axes}, typeof(Base.:(+)), Tuple{Array{Float64, 2}, Base.Irrational{:π}}})
+precompile(Tuple{typeof(Base.Broadcast.materialize), Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{2}, Nothing, typeof(Base.:(+)), Tuple{Array{Float64, 2}, Base.Irrational{:π}}}})
+precompile(Tuple{typeof(Base.Broadcast.broadcasted), Function, Array{Float64, 2}})
+precompile(Tuple{Type{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{2}, Axes, F, Args} where Args<:Tuple where F where Axes}, typeof(Base.floor), Tuple{Array{Float64, 2}}})
+precompile(Tuple{typeof(Base.Broadcast.materialize), Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{2}, Nothing, typeof(Base.floor), Tuple{Array{Float64, 2}}}})
+precompile(Tuple{typeof(Base.setindex!), Array{Float64, 3}, Array{Float64, 2}, Int64, Base.UnitRange{Int64}, Base.UnitRange{Int64}})
+precompile(Tuple{typeof(ControlSystems.nyquist), ControlSystems.StateSpace{ControlSystems.Continuous, Float64}, Array{Float64, 1}})
+precompile(Tuple{typeof(ControlSystems.isdiscrete), ControlSystems.TransferFunction{ControlSystems.Continuous, ControlSystems.SisoRational{Float64}}})
+precompile(Tuple{typeof(ControlSystems.bode), ControlSystems.TransferFunction{ControlSystems.Continuous, ControlSystems.SisoRational{Float64}}, Array{Float64, 1}})
+precompile(Tuple{typeof(ControlSystems.nyquist), ControlSystems.TransferFunction{ControlSystems.Continuous, ControlSystems.SisoRational{Float64}}, Array{Float64, 1}})
+precompile(Tuple{typeof(ControlSystems.isdiscrete), ControlSystems.StateSpace{ControlSystems.Discrete{Int64}, Float64}})
+precompile(Tuple{typeof(ControlSystems.lsim), ControlSystems.StateSpace{ControlSystems.Discrete{Int64}, Float64}, Array{Float64, 2}})
+precompile(Tuple{typeof(ControlSystems.bode), ControlSystems.StateSpace{ControlSystems.Discrete{Int64}, Float64}, Array{Float64, 1}})
+precompile(Tuple{typeof(ControlSystems.nyquist), ControlSystems.StateSpace{ControlSystems.Discrete{Int64}, Float64}, Array{Float64, 1}})
+precompile(Tuple{typeof(ControlSystems.isdiscrete), ControlSystems.TransferFunction{ControlSystems.Discrete{Int64}, ControlSystems.SisoRational{Float64}}})
+precompile(Tuple{typeof(ControlSystems.lsim), ControlSystems.TransferFunction{ControlSystems.Discrete{Int64}, ControlSystems.SisoRational{Float64}}, Array{Float64, 2}})
+precompile(Tuple{typeof(ControlSystems.siso_tf_to_ss), Type, ControlSystems.SisoRational{Float64}})
+precompile(Tuple{typeof(Base.ones), Type{Float64}, Int64})
+precompile(Tuple{Type{Pair{A, B} where B where A}, Int64, Array{Float64, 1}})
+precompile(Tuple{typeof(LinearAlgebra.diagm), Pair{Int64, Array{Float64, 1}}})
+precompile(Tuple{typeof(Base.lastindex), Array{Float64, 2}, Int64})
+precompile(Tuple{typeof(Base.maybeview), Array{Float64, 2}, Int64, Function})
+precompile(Tuple{typeof(Base.Broadcast.materialize!), Base.SubArray{Float64, 1, Array{Float64, 2}, Tuple{Int64, Base.Slice{Base.OneTo{Int64}}}, true}, Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(Base.identity), Tuple{Array{Float64, 1}}}})
+precompile(Tuple{typeof(Base.zeros), Type{Float64}, Tuple{Int64, Int64}})
+precompile(Tuple{typeof(Base.setindex!), Array{Float64, 2}, Float64, Int64})
+precompile(Tuple{typeof(Base.getindex), Array{Float64, 2}, Base.Colon})
+precompile(Tuple{typeof(Base.:(-)), Array{Float64, 1}, Array{Float64, 1}})
+precompile(Tuple{typeof(Base.setindex!), Array{Float64, 2}, Array{Float64, 1}, Base.Colon})
+precompile(Tuple{typeof(Base._array_for), Type{Tuple{Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}}}, Base.HasShape{1}, Tuple{Base.OneTo{Int64}}})
+precompile(Tuple{typeof(Base.collect_to_with_first!), Array{Tuple{Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}}, 1}, Tuple{Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}}, Base.Generator{Array{ControlSystems.SisoRational{Float64}, 1}, ControlSystems.var"#101#103"{Float64}}, Int64})
+precompile(Tuple{Type{Base.Generator{I, F} where F where I}, ControlSystems.var"#102#104", Array{Tuple{Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}}, 1}})
+precompile(Tuple{typeof(Base.collect), Base.Generator{Array{Tuple{Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}}, 1}, ControlSystems.var"#102#104"}})
+precompile(Tuple{typeof(Base.sum), Array{Int64, 1}})
+precompile(Tuple{typeof(Base.getproperty), Base.UnitRange{Int64}, Symbol})
+precompile(Tuple{typeof(Base.getindex), Array{Int64, 1}, Int64})
+precompile(Tuple{typeof(Base.getindex), Array{Tuple{Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}}, 1}, Int64})
+precompile(Tuple{typeof(Base.setindex!), Array{Float64, 2}, Array{Float64, 2}, Base.UnitRange{Int64}, Base.UnitRange{Int64}})
+precompile(Tuple{typeof(ControlSystems.balance_statespace), Array{Float64, 2}, Array{Float64, 2}, Array{Float64, 2}})
+precompile(Tuple{typeof(Base.typed_hvcat), Type{Float64}, Tuple{Int64, Int64}, Array{Float64, 2}, Vararg{Array{Float64, 2}}})
+precompile(Tuple{typeof(ControlSystems.bode), ControlSystems.TransferFunction{ControlSystems.Discrete{Int64}, ControlSystems.SisoRational{Float64}}, Array{Float64, 1}})
+precompile(Tuple{typeof(ControlSystems.nyquist), ControlSystems.TransferFunction{ControlSystems.Discrete{Int64}, ControlSystems.SisoRational{Float64}}, Array{Float64, 1}})
+
+
+
+#=
+# Without system image =========================================================
+Without precompile
+julia> @time using ControlSystems
+  7.822230 seconds (21.90 M allocations: 1.456 GiB, 6.56% gc time, 27.95% compilation time)
+
+julia> @time include("/home/fredrikb/.julia/dev/ControlSystems/src/generate_precompile.jl")
+ 11.008634 seconds (39.06 M allocations: 2.066 GiB, 3.96% gc time, 99.93% compilation time)
+
+With precompile
+julia> @time using ControlSystems
+  7.844937 seconds (22.21 M allocations: 1.480 GiB, 7.17% gc time, 27.12% compilation time)
+
+julia> @time include("/home/fredrikb/.julia/dev/ControlSystems/generate_precompile.jl")
+  5.880538 seconds (20.11 M allocations: 1.005 GiB, 2.29% gc time, 99.87% compilation time)
+
+# With system image containing DiffEq ==========================================
+Without precompile 
+julia> @time using ControlSystems
+  0.115509 seconds (436.63 k allocations: 27.015 MiB, 1.73% compilation time)
+
+julia> @time include("/home/fredrikb/.julia/dev/ControlSystems/generate_precompile.jl")
+  8.284839 seconds (29.01 M allocations: 1.524 GiB, 11.79% gc time, 99.92% compilation time)
+
+
+With precompile
+julia> @time using ControlSystems
+  0.259895 seconds (705.27 k allocations: 52.725 MiB, 0.76% compilation time)
+
+julia> @time include("/home/fredrikb/.julia/dev/ControlSystems/generate_precompile.jl")
+  5.205052 seconds (14.55 M allocations: 741.343 MiB, 8.35% gc time, 99.86% compilation time)
+
+=#


### PR DESCRIPTION
I'm marking this as a draft. The current benefit is not really large enough to include, but 
- https://github.com/JuliaLang/julia/pull/43990

may make it more worthwhile. In particular, I'm worried about the extra overhead incurred by developers of the package, hence the experimentation with
```julia
if !(occursin(joinpath(".julia", "dev"), __CONTROLSYSTEMS_SOURCE_DIR__))
    # Only precompile if the package is not checked out for development. Precompilation takes about 6 seconds, and saves about 2-3 seconds on the compilation script. For a user loading the same version of the package multiple times, precompilation makes the experience slightly more snappy. For a developer, paying the precompilation price each time the package has been modified is unlikely to be beneficial.
    include("precompile.jl")
end
```

The user may save about 2 seconds on a simple but representative workflow, but the loading time of the package goes up by about 0.15s. The *precompilation time* of the package will, however, go up with a whopping 4 seconds, so unless there is a bigger benefit of the precompilation, I'm not sure it's worth it.