### PR TITLE
type stability in blockdiag

### DIFF
--- a/src/connections.jl
+++ b/src/connections.jl
@@ -133,9 +133,13 @@ function /(sys1::Union{StateSpace,AbstractStateSpace}, sys2::LTISystem)
     return sys1new*sys2new
 end
 
-
-blockdiag(anything...) = cat(anything..., dims=(1,2))
-blockdiag(anything::Union{<:Tuple, <:Base.Generator}) = cat(anything..., dims=(1,2))
+@static if VERSION >= v"1.8.0-beta1"
+    blockdiag(anything...) = cat(anything..., dims=Val((1,2)))
+    blockdiag(anything::Union{<:Tuple, <:Base.Generator}) = cat(anything..., dims=Val((1,2)))
+else
+    blockdiag(anything...) = cat(anything..., dims=(1,2))
+    blockdiag(anything::Union{<:Tuple, <:Base.Generator}) = cat(anything..., dims=(1,2))
+end
 
 
 """


### PR DESCRIPTION
only available in julia v1.8 and up.

In v1.7, the result is inferred to `Any`, which causes *internal* type instabilities in all `cat, hcat, vcat` functions. 