### PR TITLE
faster lsim for cont systems

### DIFF
--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -171,9 +171,11 @@ function lsim(sys::AbstractStateSpace, u::Function, tfinal::Real; kwargs...)
 end
 
 # Function for DifferentialEquations lsim
-function f_lsim(dx, x, p, t) 
+@inline function f_lsim(dx, x, p, t) 
     A, B, u = p
-    dx .= A * x .+ B * u(x, t)
+    # dx .= A * x .+ B * u(x, t)
+    mul!(dx, A, x)
+    mul!(dx, B, u(x, t), 1, 1)
 end
 
 function lsim(sys::AbstractStateSpace, u::Function, t::AbstractVector;

--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -15,8 +15,9 @@ function Base.step(sys::AbstractStateSpace, t::AbstractVector; method=:cont, kwa
     T = promote_type(eltype(sys.A), Float64)
     ny, nu = size(sys)
     nx = nstates(sys)
-    u_element = [one(eltype(t))] # to avoid allocating this multiple times
-    u = (x,t)->u_element
+    u = let u_element = [one(eltype(t))] # to avoid allocating this multiple times
+        (x,t)->u_element
+    end
     x0 = zeros(T, nx)
     if nu == 1
         y, tout, x, uout = lsim(sys, u, t; x0, method, kwargs...)
@@ -205,8 +206,11 @@ function lsim(sys::AbstractStateSpace, u::Function, t::AbstractVector;
     else
         p = (sys.A, sys.B, u)
         sol = solve(ODEProblem(f_lsim, x0, (t[1], t[end]+dt/2), p), alg; saveat=t, kwargs...)
-        x = reduce(hcat, sol.u)
-        uout = reduce(hcat, u(x[:, i], t[i]) for i in eachindex(t))
+        x = reduce(hcat, sol.u)::Matrix{T}
+        uout = Matrix{T}(undef, nu, length(t))
+        for i = eachindex(t)
+            uout[:, i] = u(@view(x[:, i]), t[i])
+        end
         simsys = sys
     end
     y = sys.C*x


### PR DESCRIPTION
```
julia> @btime step($sysss, $t);
  689.942 μs (8510 allocations: 3.07 MiB) before

julia> @btime step($sysss, $t);
  632.183 μs (4706 allocations: 2.43 MiB) inplace mul

julia> @btime step($sysss, $t);
  601.745 μs (4706 allocations: 2.43 MiB) inline
```

---

It turns out that the `reduce(hcat, generator)` for `uout` had quadratic time complexity, making it take *far* longer than the solve for long solves.

```julia
julia> @btime step($sysss, $t);
  516.064 μs (4698 allocations: 2.40 MiB) view 
  
julia> @btime step($sysss, $t);
  492.480 μs (4702 allocations: 2.40 MiB) let
  
julia> @btime step($sysss, $t);
  205.648 μs (1674 allocations: 306.44 KiB) loop over uout ( check diff in memory)
```

The problem that led me to find this bug went from
```julia
21.450054 seconds (2.57 M allocations: 116.727 GiB, 31.64% gc time)
```
to
```julia
0.084840 seconds (254.81 k allocations: 99.293 MiB)
```