### PR TITLE
zpk conjugate pairup fails on 0.0 and -0.0

### DIFF
--- a/src/types/SisoTfTypes/SisoZpk.jl
+++ b/src/types/SisoTfTypes/SisoZpk.jl
@@ -113,7 +113,7 @@ function pairup_conjugates!(x::AbstractVector)
         imag(x[i]) == 0 && continue
 
         # Attempt to find a matching conjugate to x[i]
-        j = findnext(isequal(conj(x[i])), x, i+1)
+        j = findnext(==(conj(x[i])), x, i+1)
         j === nothing && return false
 
         tmp = x[j]


### PR DESCRIPTION
I ran in to this just now, seems like this should fix it.

Problem is that 
```julia
julia> isequal(0.0, -0.0)
false

julia> ==(0.0, -0.0)
true
```

```julia
julia> H = tf([0.65, 0, 0.45], [1, 0, 0], 0.2)
TransferFunction{Discrete{Float64}, ControlSystems.SisoRational{Float64}}
0.65z^2 + 0.45
--------------
    1.0z^2

Sample Time: 0.2 (seconds)
Discrete-time transfer function model

julia> bodeplot(H)
ERROR: ArgumentError: zpk model should be real-valued, but zeros do not come in conjugate pairs.
Stacktrace:
  [1] ControlSystems.SisoZpk{Float64, ComplexF64}(z::Vector{ComplexF64}, p::Vector{ComplexF64}, k::Float64)
    @ ControlSystems ~/.julia/packages/ControlSystems/lbxGy/src/types/SisoTfTypes/SisoZpk.jl:16
  [2] ControlSystems.SisoZpk{Float64, ComplexF64}(z::Vector{ComplexF64}, p::Vector{Float64}, k::Float64)
    @ ControlSystems ~/.julia/packages/ControlSystems/lbxGy/src/types/SisoTfTypes/SisoZpk.jl:23
  [3] convert(#unused#::Type{ControlSystems.SisoZpk{Float64, ComplexF64}}, f::ControlSystems.SisoRational{Float64})
    @ ControlSystems ~/.julia/packages/ControlSystems/lbxGy/src/types/SisoTfTypes/conversion.jl:8
  [4] convert
    @ ~/.julia/packages/ControlSystems/lbxGy/src/types/SisoTfTypes/conversion.jl:14 [inlined]
  [5] _broadcast_getindex_evalf
    @ ./broadcast.jl:670 [inlined]
  [6] _broadcast_getindex
    @ ./broadcast.jl:653 [inlined]
  [7] getindex
    @ ./broadcast.jl:597 [inlined]
  [8] copy
    @ ./broadcast.jl:899 [inlined]
  [9] materialize
    @ ./broadcast.jl:860 [inlined]
 [10] convert(#unused#::Type{TransferFunction{Discrete{Float64}, ControlSystems.SisoZpk}}, G::TransferFunction{Discrete{Float64}, ControlSystems.SisoRational{Float64}})
    @ ControlSystems ~/.julia/packages/ControlSystems/lbxGy/src/types/conversion.jl:60
 [11] zpkdata
    @ ~/.julia/packages/ControlSystems/lbxGy/src/analysis.jl:132 [inlined]
 [12] _bounds_and_features(sys::TransferFunction{Discrete{Float64}, ControlSystems.SisoRational{Float64}}, plot::Val{:bode})
    @ ControlSystems ~/.julia/packages/ControlSystems/lbxGy/src/freqresp.jl:321
 [13] #157
    @ ~/.julia/packages/ControlSystems/lbxGy/src/freqresp.jl:307 [inlined]
 [14] iterate
    @ ./generator.jl:47 [inlined]
 [15] _collect(c::Vector{TransferFunction{Discrete{Float64}, ControlSystems.SisoRational{Float64}}}, itr::Base.Generator{Vector{TransferFunction{Discrete{Float64}, ControlSystems.SisoRational{Float64}}}, ControlSystems.var"#157#158"{Val{:bode}}}, #unused#::Base.EltypeUnknown, isz::Base.HasShape{1})
    @ Base ./array.jl:744
 [16] collect_similar(cont::Vector{TransferFunction{Discrete{Float64}, ControlSystems.SisoRational{Float64}}}, itr::Base.Generator{Vector{TransferFunction{Discrete{Float64}, ControlSystems.SisoRational{Float64}}}, ControlSystems.var"#157#158"{Val{:bode}}})
    @ Base ./array.jl:653
 [17] map(f::Function, A::Vector{TransferFunction{Discrete{Float64}, ControlSystems.SisoRational{Float64}}})
    @ Base ./abstractarray.jl:2849
 [18] _default_freq_vector(systems::Vector{TransferFunction{Discrete{Float64}, ControlSystems.SisoRational{Float64}}}, plot::Val{:bode})
    @ ControlSystems ~/.julia/packages/ControlSystems/lbxGy/src/freqresp.jl:307
 [19] _processfreqplot(plottype::Val{:bode}, systems::Vector{TransferFunction{Discrete{Float64}, ControlSystems.SisoRational{Float64}}})
    @ ControlSystems ~/.julia/packages/ControlSystems/lbxGy/src/plotting.jl:181
 [20] _processfreqplot(::Val{:bode}, ::TransferFunction{Discrete{Float64}, ControlSystems.SisoRational{Float64}})
    @ ControlSystems ~/.julia/packages/ControlSystems/lbxGy/src/plotting.jl:173
 [21] macro expansion
    @ ~/.julia/packages/ControlSystems/lbxGy/src/plotting.jl:204 [inlined]
 [22] apply_recipe(plotattributes::AbstractDict{Symbol, Any}, p::ControlSystems.Bodeplot)
    @ ControlSystems ~/.julia/packages/RecipesBase/qpxEX/src/RecipesBase.jl:289
 [23] _process_userrecipes!(plt::Any, plotattributes::Any, args::Any)
    @ RecipesPipeline ~/.julia/packages/RecipesPipeline/oVorB/src/user_recipe.jl:36
 [24] recipe_pipeline!(plt::Any, plotattributes::Any, args::Any)
    @ RecipesPipeline ~/.julia/packages/RecipesPipeline/oVorB/src/RecipesPipeline.jl:70
 [25] _plot!(plt::Plots.Plot, plotattributes::Any, args::Any)
    @ Plots ~/.julia/packages/Plots/LI4FE/src/plot.jl:208
 [26] plot(args::Any; kw::Base.Pairs{Symbol, V, Tuple{Vararg{Symbol, N}}, NamedTuple{names, T}} where {V, N, names, T<:Tuple{Vararg{Any, N}}})
    @ Plots ~/.julia/packages/Plots/LI4FE/src/plot.jl:91
 [27] plot
    @ ~/.julia/packages/Plots/LI4FE/src/plot.jl:85 [inlined]
 [28] bodeplot(::TransferFunction{Discrete{Float64}, ControlSystems.SisoRational{Float64}}, ::Vararg{Any}; kw::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ ControlSystems ~/.julia/packages/RecipesBase/qpxEX/src/RecipesBase.jl:364
 [29] bodeplot(::TransferFunction{Discrete{Float64}, ControlSystems.SisoRational{Float64}}, ::Vararg{Any})
    @ ControlSystems ~/.julia/packages/RecipesBase/qpxEX/src/RecipesBase.jl:364
 [30] top-level scope
    @ REPL[41]:1
```