### PR TITLE
Better `bode` performance

### DIFF
--- a/src/ControlSystems.jl
+++ b/src/ControlSystems.jl
@@ -76,6 +76,8 @@ export  LTISystem,
         freqresp, freqrespv, freqresp!,
         evalfr,
         bode, bodev,
+        bodemag!,
+        BodemagWorkspace,
         nyquist, nyquistv,
         sigma, sigmav,
         # delay systems

--- a/test/test_freqresp.jl
+++ b/test/test_freqresp.jl
@@ -115,6 +115,8 @@ for (i,w) in enumerate(ws)
 end
 
 @test bode(sys, ws)[1:2] == (abs.(resp), rad2deg.(angle.(resp)))
+workspace = BodemagWorkspace(sys, ws)
+@test bode(sys, ws)[1] == permutedims(bodemag!(workspace, sys, ws), (3,1,2))
 @test nyquist(sys, ws)[1:2] == (real(resp), imag(resp))
 sigs = Array{Float64}(undef, 50,2)
 for i in eachindex(ws)


### PR DESCRIPTION
The phase unwrapping is extremely expensive (makes `bode` over 10x slower in the example below), so it's made optional. Also add a function that only computes the magnitude in-place for zero allocations.
```julia
using ControlSystems
G = tf(ssrand(2,2,5))
w = exp10.(LinRange(-2, 2, 20000))
@btime bode($G, $w);
# 55.120 ms (517957 allocations: 24.42 MiB)
@btime bode($G, $w, unwrap=false);
# 3.624 ms (7 allocations: 2.44 MiB)
ws = ControlSystems.BodemagWorkspace(G, w)
@btime bodemag!($ws, $G, $w);
# 2.991 ms (1 allocation: 64 bytes)
```