### PR TITLE
Add argument to nyquistplot for critical point

### DIFF
--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -306,7 +306,7 @@ If `hz=true`, the hover information will be displayed in Hertz, the input freque
 `kwargs` is sent as argument to plot.
 """
 nyquistplot
-@recipe function nyquistplot(p::Nyquistplot; Ms_circles=Float64[], unit_circle=false, hz=false)
+@recipe function nyquistplot(p::Nyquistplot; Ms_circles=Float64[], unit_circle=false, hz=false, critical_origin=false)
     systems, w = _processfreqplot(Val{:nyquist}(), p.args...)
     ny, nu = size(systems[1])
     nw = length(w)
@@ -340,7 +340,7 @@ nyquistplot
                         seriescolor := :red
                         markersize := 5
                         seriesstyle := :scatter
-                        [-1], [0]
+                        [critical_origin ? 0 : -1], [0]
                     end
                     for Ms in Ms_circles
                         @series begin

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -306,7 +306,7 @@ If `hz=true`, the hover information will be displayed in Hertz, the input freque
 `kwargs` is sent as argument to plot.
 """
 nyquistplot
-@recipe function nyquistplot(p::Nyquistplot; Ms_circles=Float64[], unit_circle=false, hz=false, critical_origin=false)
+@recipe function nyquistplot(p::Nyquistplot; Ms_circles=Float64[], unit_circle=false, hz=false, critical_point=-1)
     systems, w = _processfreqplot(Val{:nyquist}(), p.args...)
     ny, nu = size(systems[1])
     nw = length(w)
@@ -340,7 +340,7 @@ nyquistplot
                         seriescolor := :red
                         markersize := 5
                         seriesstyle := :scatter
-                        [critical_origin ? 0 : -1], [0]
+                        [critical_point], [0]
                     end
                     for Ms in Ms_circles
                         @series begin

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -292,14 +292,15 @@ end
 
 @userplot Nyquistplot
 """
-    fig = nyquistplot(sys; Ms_circles=Float64[], unit_circle=false, hz = false, kwargs...)
-    nyquistplot(LTISystem[sys1, sys2...]; Ms_circles=Float64[], unit_circle=false, kwargs...)
+    fig = nyquistplot(sys; Ms_circles=Float64[], unit_circle=false, hz=false, critical_point=-1, kwargs...)
+    nyquistplot(LTISystem[sys1, sys2...]; Ms_circles=Float64[], unit_circle=false, hz=false, critical_point=-1, kwargs...)
 
 Create a Nyquist plot of the `LTISystem`(s). A frequency vector `w` can be
 optionally provided.
 
 - `unit_circle`: if the unit circle should be displayed
 - `Ms_circles`: draw circles corresponding to given levels of sensitivity (circles around -1 with  radii `1/Ms`). `Ms_circles` can be supplied as a number or a vector of numbers. A design staying outside such a circle has a phase margin of at least `2asin(1/(2Ms))` rad and a gain margin of at least `Ms/(Ms-1)`.
+- `critical_point`: point on real axis to mark as critical for encirclements
 
 If `hz=true`, the hover information will be displayed in Hertz, the input frequency vector is still treated as rad/s.
 


### PR DESCRIPTION
Considering a Nyquist plot for the return difference F = 1 + L, we should mark the origin as the critical point instead of -1. Similarly, it allows plotting of the determinant of the return difference for a MIMO system, as we necessarily need to test encirclements of the origin. Default remains -1 as the critical point.