### PR TITLE
don't convert type of time vector

### DIFF
--- a/src/timeresp.jl
+++ b/src/timeresp.jl
@@ -235,7 +235,7 @@ function lsim(sys::AbstractStateSpace, u::Function, t::AbstractVector;
     end
     T = promote_type(Float64, eltype(x0), numeric_type(sys))
 
-    dt = T(t[2] - t[1])
+    dt = t[2] - t[1]
 
     if !iscontinuous(sys) || method === :zoh
         if iscontinuous(sys)


### PR DESCRIPTION
Because it fails if `T` is a type that don't support `nextfloat` and `AbstractFloat`. The user now has direct control over `t` which is more useful.