### PR TITLE
fix non-commutativity of multiplication for nonlinear systems

### DIFF
--- a/src/types/LFTSystem.jl
+++ b/src/types/LFTSystem.jl
@@ -9,7 +9,7 @@ end
 
 function *(sys::LFTSystem, n::Number)
     new_B = [sys.P.B1*n sys.P.B2]
-    new_D = [sys.P.D11 sys.P.D12*n; sys.P.D21 sys.P.D22*n]
+    new_D = [sys.P.D11*n sys.P.D12; sys.P.D21*n sys.P.D22]
     return basetype(sys)(StateSpace(sys.P.A, new_B, sys.P.C, new_D, sys.P.timeevol), feedback_channel(sys))
 end
 

--- a/src/types/LFTSystem.jl
+++ b/src/types/LFTSystem.jl
@@ -1,12 +1,17 @@
 abstract type LFTSystem{TE, T} <: LTISystem{TE} end
 timeevol(sys::LFTSystem) = timeevol(sys.P)
 
-function *(sys::LFTSystem, n::Number)
+function *(n::Number, sys::LFTSystem)
     new_C = [sys.P.C1*n; sys.P.C2]
     new_D = [sys.P.D11*n sys.P.D12*n; sys.P.D21 sys.P.D22]
     return basetype(sys)(StateSpace(sys.P.A, sys.P.B, new_C, new_D, sys.P.timeevol), feedback_channel(sys))
 end
-*(n::Number, sys::LFTSystem) = *(sys, n)
+
+function *(sys::LFTSystem, n::Number)
+    new_B = [sys.P.B1*n sys.P.B2]
+    new_D = [sys.P.D11 sys.P.D12*n; sys.P.D21 sys.P.D22*n]
+    return basetype(sys)(StateSpace(sys.P.A, new_B, sys.P.C, new_D, sys.P.timeevol), feedback_channel(sys))
+end
 
 
 function +(sys::LFTSystem{TE,T1}, n::T2) where {TE,T1,T2<:Number}

--- a/src/types/StateSpace.jl
+++ b/src/types/StateSpace.jl
@@ -284,8 +284,9 @@ function *(sys1::ST, sys2::ST) where {ST <: AbstractStateSpace}
     return basetype(ST)(A, B, C, D, timeevol)
 end
 
-*(sys::ST, n::Number) where ST <: AbstractStateSpace = basetype(ST)(sys.A, sys.B, sys.C*n, sys.D*n, sys.timeevol)
-*(n::Number, sys::AbstractStateSpace) = *(sys, n)
+*(sys::ST, n::Number) where ST <: AbstractStateSpace = basetype(ST)(sys.A, sys.B*n, sys.C, sys.D*n, sys.timeevol)
+*(n::Number, sys::ST) where ST <: AbstractStateSpace = basetype(ST)(sys.A, sys.B, sys.C*n, sys.D*n, sys.timeevol)
+
 
 ## DIVISION ##
 /(sys1::AbstractStateSpace, sys2::AbstractStateSpace) = sys1*inv(sys2)
@@ -302,7 +303,8 @@ function /(n::Number, sys::ST) where ST <: AbstractStateSpace
 end
 
 Base.inv(sys::AbstractStateSpace) = 1/sys
-/(sys::ST, n::Number) where ST <: AbstractStateSpace = basetype(ST)(sys.A, sys.B, sys.C/n, sys.D/n, sys.timeevol)
+/(sys::ST, n::Number) where ST <: AbstractStateSpace = basetype(ST)(sys.A, sys.B/n, sys.C, sys.D/n, sys.timeevol)
+Base.:\(n::Number, sys::ST) where ST <: AbstractStateSpace = basetype(ST)(sys.A, sys.B, sys.C/n, sys.D/n, sys.timeevol)
 
 
 #####################################################################

--- a/test/test_delayed_systems.jl
+++ b/test/test_delayed_systems.jl
@@ -81,6 +81,7 @@ s_vec = [0, 1im, 1, 1 + 1im]
 @test freqresp(feedback(1.0, P1*delay(1)), ω)[:] ≈ 1 ./ (1 .+ exp.(-im*ω) .* P1_fr) rtol=1e-15
 
 @test freqresp(feedback(1.0, P2*0.5*(ss(1.0) + delay(2))), ω)[:] ≈ 1 ./(1 .+ P2_fr .* 0.5.*(1 .+ exp.(-2*im*ω)))
+@test freqresp(feedback(1.0, 0.5*P2*(ss(1.0) + delay(2))), ω)[:] ≈ 1 ./(1 .+ P2_fr .* 0.5.*(1 .+ exp.(-2*im*ω)))
 
 
 @test freqresp(1.0 + delay(2), ω)[:] ≈ 1 .+ exp.(-2im*ω) rtol=1e-15

--- a/test/test_statespace.jl
+++ b/test/test_statespace.jl
@@ -87,6 +87,19 @@
         @inferred C_111 * C_221
         @inferred C_111 * I(2)
 
+        # Test that multiplication/division is applied at correct input/output location
+        @test (10*C_111).C == 10*C_111.C
+        @test (10*C_111).B == C_111.B
+
+        @test (C_111*10).C == C_111.C
+        @test (C_111*10).B == 10*C_111.B
+
+        @test (10\C_111).C == 10\C_111.C
+        @test (10\C_111).B == C_111.B
+
+        @test (C_111/10).C == C_111.C
+        @test (C_111/10).B == C_111.B/10
+
         # Division
         @test 1/C_222_d == SS([-6 -3; 2 -11],[1 0; 0 2],[-1 0; -0 -1],[1 -0; 0 1])
         @test C_221/C_222_d == SS([-5 -3 -1 0; 2 -9 -0 -2; 0 0 -6 -3;


### PR DESCRIPTION
`10*sys` and `sys*10` are not the same if `sys` is nonlinear.

This PR also fixes so that the code above multiplies `C` if applied at output and `B` if applied at input for regular `StateSpace` systems since the state magnitude is different in simulation between the two cases.