### PR TITLE
Don't treat Q's like easily readable arrays

### DIFF
--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -235,7 +235,7 @@ function tzeros(A::AbstractMatrix{T}, B::AbstractMatrix{T}, C::AbstractMatrix{T}
     # Step 3:
     # Compress cols of [C D] to [0 Df]
     mat = [C_rc D_rc]
-    Wr = Matrix(qr(mat').Q)
+    Wr = qr(mat').Q * I
     W = reverse(Wr, dims=2)
     mat = mat*W
     if fastrank(mat', meps) > 0
@@ -277,7 +277,7 @@ function reduce_sys(A::AbstractMatrix, B::AbstractMatrix, C::AbstractMatrix, D::
         end
 
         # Compress columns of Ctilde
-        V = reverse(Matrix(qr(Ctilde').Q), dims=2)
+        V = reverse(qr(Ctilde').Q * I, dims=2)
         Sj = Ctilde*V
         rho = fastrank(Sj', meps)
         nu = size(Sj, 2) - rho

--- a/src/analysis.jl
+++ b/src/analysis.jl
@@ -235,7 +235,7 @@ function tzeros(A::AbstractMatrix{T}, B::AbstractMatrix{T}, C::AbstractMatrix{T}
     # Step 3:
     # Compress cols of [C D] to [0 Df]
     mat = [C_rc D_rc]
-    Wr = qr(mat').Q
+    Wr = Matrix(qr(mat').Q)
     W = reverse(Wr, dims=2)
     mat = mat*W
     if fastrank(mat', meps) > 0
@@ -277,7 +277,7 @@ function reduce_sys(A::AbstractMatrix, B::AbstractMatrix, C::AbstractMatrix, D::
         end
 
         # Compress columns of Ctilde
-        V = reverse(qr(Ctilde').Q, dims=2)
+        V = reverse(Matrix(qr(Ctilde').Q), dims=2)
         Sj = Ctilde*V
         rho = fastrank(Sj', meps)
         nu = size(Sj, 2) - rho


### PR DESCRIPTION
This came up in a nanosoldier run in https://github.com/JuliaLang/julia/pull/46196. Independently from that PR, this usage of `revert` here is supposedly really slow, because there's no quick `getindex` for `qr(A).Q`s. I added calls to `Matrix`, which may yield rectangular matrices in the tall case. I'll propose another solution below if you insist on the square representation.