### PR TITLE
increase timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
   runtests: 
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }} 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Julia v1.8 brought with it a massive increase in compile times :(
Unfortunately, the tests now take roughly 3x longer to run on my local machine compared to for julia v1.7.3
The regression has been reported, but until then, I try to just increase the timeout threshold