### PR TITLE
reduce allocations and compile time in feedback

### DIFF
--- a/test/test_staticsystems.jl
+++ b/test/test_staticsystems.jl
@@ -135,7 +135,7 @@ eye, sys2 = promote(1, sys)
 promote_type(typeof(StaticStateSpace(ssrand(1,1,1,Ts=0.1))), typeof(1)) == HeteroStateSpace{Discrete{Float64}}
 
 sys = StaticStateSpace(ssrand(1,1,2,proper=false))
-@test feedback(sys,sys) == feedback(ss(sys),ss(sys))
+@test feedback(sys,sys) ≈ feedback(ss(sys),ss(sys))
 @inferred  feedback(sys,sys)
 
 ## Freqresp


### PR DESCRIPTION
This PR reduces the compile time of `feedback(G)` from 5s to 2.6s while also reducing the runtime allocations by approx 50% for the most common path `iszero(s1_D22) || iszero(s2_D22)`. This comes at the expense of slightly uglier code, but I think the performance improvements are worth it for such a fundamental function