### PR TITLE
add `extended_gangoffour`

### DIFF
--- a/lib/ControlSystemsBase/src/ControlSystemsBase.jl
+++ b/lib/ControlSystemsBase/src/ControlSystemsBase.jl
@@ -56,6 +56,7 @@ export  LTISystem,
         margin,
         delaymargin,
         gangoffour,
+        extended_gangoffour,
         relative_gain_array,
         # Connections
         append,

--- a/lib/ControlSystemsBase/src/pid_design.jl
+++ b/lib/ControlSystemsBase/src/pid_design.jl
@@ -176,7 +176,7 @@ end
 
 
 """
-    leadlink(b, N, K; [Ts])
+    leadlink(b, N, K=1; [Ts])
 
 Returns a phase advancing link, the top of the phase curve is located at `ω = b√(N)` where the link amplification is `K√(N)` The bode curve will go from `K`, bend up at `b` and level out at `KN` for frequencies > `bN`
 
@@ -190,7 +190,7 @@ KN \\dfrac{s + b}{s + bN} = K \\dfrac{1 + s/b}{1 + s/(bN)}
 
 See also `leadlinkat` `laglink`
 """
-function leadlink(b, N, K; h=nothing, Ts=nothing)
+function leadlink(b, N, K=1; h=nothing, Ts=nothing)
     Ts !== nothing && (Ts ≥ 0 || throw(ArgumentError("Negative `Ts` is not supported.")))
     N > 1 || @warn "N should be ≥ 1 for the link to be phase advancing."
     numerator = [1/b, 1]
@@ -202,7 +202,7 @@ function leadlink(b, N, K; h=nothing, Ts=nothing)
 end
 
 """
-    leadlinkat(ω, N, K; [Ts])
+    leadlinkat(ω, N, K=1; [Ts])
 
 Returns a phase advancing link, the top of the phase curve is located at `ω` where the link amplification is `K√(N)` The bode curve will go from `K`, bend up at `ω/√(N)` and level out at `KN` for frequencies > `ω√(N)`
 
@@ -212,7 +212,7 @@ Values of `N < 1` will give a phase retarding link.
 
 See also `leadlink` `laglink`
 """
-function leadlinkat(ω, N, K; Ts=nothing)
+function leadlinkat(ω, N, K=1; Ts=nothing)
     b = ω / sqrt(N)
     return leadlink(b,N,K,Ts=Ts)
 end

--- a/lib/ControlSystemsBase/src/sensitivity_functions.jl
+++ b/lib/ControlSystemsBase/src/sensitivity_functions.jl
@@ -103,3 +103,66 @@ function output_comp_sensitivity(P,C)
     feedback(P * C)
 end
 
+"""
+    extended_gangoffour(P, C, pos=true)
+
+Returns a single statespace system that maps 
+- `w1` reference or measurement noise
+- `w2` load disturbance
+to
+- `z1` control error
+- `z2` control input
+```
+      z1          z2
+      ▲  ┌─────┐  ▲      ┌─────┐
+      │  │     │  │      │     │
+w1──+─┴─►│  C  ├──┴───+─►│  P  ├─┐
+    │    │     │      │  │     │ │
+    │    └─────┘      │  └─────┘ │
+    │                 w2         │
+    └────────────────────────────┘
+```
+
+The returned system has the transfer-function matrix
+```math
+\\begin{bmatrix}
+I \\\\ C
+\\end{bmatrix} (I + PC)^{-1} \\begin{bmatrix}
+I & P
+\\end{bmatrix}
+```
+or in code
+```julia
+# For SISO P
+S  = G[1, 1]
+PS = G[1, 2]
+CS = G[2, 1]
+T  = G[2, 2]
+
+# For MIMO P
+S  = G[1:P.ny,     1:P.nu]
+PS = G[1:P.ny,     P.nu+1:end]
+CS = G[P.ny+1:end, 1:P.nu]
+T  = G[P.ny+1:end, P.nu+1:end]
+```
+
+The gang of four can be plotted like so
+```julia
+Gcl = extended_gangoffour(G, C) # Form closed-loop system
+bodeplot(Gcl, lab=["S" "CS" "PS" "T"], plotphase=false) |> display # Plot gang of four
+```
+Note, the last output of Gcl is the negative of the `CS` and `T` transfer functions from `gangoffour2`. To get a transfer matrix with the same sign as [`G_CS`](@ref) and [`comp_sensitivity`](@ref), call `extended_gangoffour(P, C, pos=false)`.
+See [`glover_mcfarlane`](@ref) from RobustAndOptimalControl.jl for an extended example. See also [`ncfmargin`](@ref) and [`feedback_control`](@ref) from RobustAndOptimalControl.jl.
+"""
+function extended_gangoffour(P, C, pos=true)
+    ny,nu = size(P)
+    te = P.timeevol
+    if pos
+        S = feedback(ss(I(ny+nu), P.timeevol), [ss(0*I(ny), te) P; -C ss(0*I(nu), te)], pos_feedback=true)
+        return S + cat(0*I(ny), -I(nu), dims=(1,2))
+    else
+        Gtop = [I(ny); C] * [I(ny) P]
+        return feedback(Gtop, ss(I(nu)), U1=(1:nu).+ny, Y1=(1:nu).+ny, pos_feedback=false)
+    end
+end
+

--- a/lib/ControlSystemsBase/test/test_connections.jl
+++ b/lib/ControlSystemsBase/test/test_connections.jl
@@ -377,4 +377,14 @@ e22 = lsim(C, e42).y
 @test sensitivity(P,C) == output_sensitivity(P,C)
 @test comp_sensitivity(P,C) == output_comp_sensitivity(P,C)
 
+P = ssrand(1,2,1,proper=false)
+K = ssrand(2,1,1,proper=false)
+G = extended_gangoffour(P, K, false)
+@test tf(G[1,1]) ≈ tf(sensitivity(P, K))
+@test tf(G[2,1]) ≈ tf(G_CS(P, K))
+
+G = extended_gangoffour(P, K, true)
+@test tf(G[1,1]) ≈ tf(sensitivity(P, K))
+@test tf(G[2,1]) ≈ tf(-G_CS(P, K))
+
 end


### PR DESCRIPTION
This function [previously resided in RobustAndOptimalControl.jl](https://juliacontrol.github.io/RobustAndOptimalControl.jl/dev/api/#RobustAndOptimalControl.extended_gangoffour), but is generally useful. If all sensitivity functions in the gang of four are required, it's more efficient to compute this single system than four separate systems containing mostly the same matrix elements.