### PR TITLE
extended_gangoffour sign fix

### DIFF
--- a/lib/ControlSystemsBase/src/sensitivity_functions.jl
+++ b/lib/ControlSystemsBase/src/sensitivity_functions.jl
@@ -158,14 +158,14 @@ The gang of four can be plotted like so
 Gcl = extended_gangoffour(G, C) # Form closed-loop system
 bodeplot(Gcl, lab=["S" "CS" "PS" "T"], plotphase=false) |> display # Plot gang of four
 ```
-Note, the last output of Gcl is the negative of the `CS` and `T` transfer functions from `gangoffour2`. To get a transfer matrix with the same sign as [`G_CS`](@ref) and [`comp_sensitivity`](@ref), call `extended_gangoffour(P, C, pos=false)`.
+Note, the last input of Gcl is the negative of the `PS` and `T` transfer functions from `gangoffour2`. To get a transfer matrix with the same sign as [`G_PS`](@ref) and [`input_comp_sensitivity`](@ref), call `extended_gangoffour(P, C, pos=false)`.
 See [`glover_mcfarlane`](@ref) from RobustAndOptimalControl.jl for an extended example. See also [`ncfmargin`](@ref) and [`feedback_control`](@ref) from RobustAndOptimalControl.jl.
 """
 function extended_gangoffour(P, C, pos=true)
     ny,nu = size(P)
     te = P.timeevol
     if pos
-        S = feedback(ss(I(ny+nu), P.timeevol), [ss(0*I(ny), te) P; -C ss(0*I(nu), te)], pos_feedback=true)
+        S = feedback(ss(I(ny+nu), P.timeevol), [ss(0*I(ny), te) -P; C ss(0*I(nu), te)], pos_feedback=true)
         return S + cat(0*I(ny), -I(nu), dims=(1,2))
     else
         Gtop = [I(ny); C] * [I(ny) P]

--- a/lib/ControlSystemsBase/test/test_connections.jl
+++ b/lib/ControlSystemsBase/test/test_connections.jl
@@ -382,9 +382,14 @@ K = ssrand(2,1,1,proper=false)
 G = extended_gangoffour(P, K, false)
 @test tf(G[1,1]) ≈ tf(sensitivity(P, K))
 @test tf(G[2,1]) ≈ tf(G_CS(P, K))
+@test tf(G[1,2]) ≈ tf(G_PS(P, K))
+@test tf(G[2,2]) ≈ tf(input_comp_sensitivity(P, K))
+
 
 G = extended_gangoffour(P, K, true)
 @test tf(G[1,1]) ≈ tf(sensitivity(P, K))
-@test tf(G[2,1]) ≈ tf(-G_CS(P, K))
+@test tf(G[2,1]) ≈ tf(G_CS(P, K))
+@test tf(G[1,2]) ≈ tf(-G_PS(P, K))
+@test tf(G[2,2]) ≈ tf(-input_comp_sensitivity(P, K))
 
 end


### PR DESCRIPTION
Make the returned transfer function have the same signs as in the block diagram