### PR TITLE
Automatically select line color for plotting the unit circle in `pzmap`.

### DIFF
--- a/lib/ControlSystemsBase/src/plotting.jl
+++ b/lib/ControlSystemsBase/src/plotting.jl
@@ -770,7 +770,6 @@ pzmap
                 seriestype := :shape
                 fillalpha := 0
                 Plots.partialcircle(0, 2π, 100)
-                C,S
             end
         end
     end

--- a/lib/ControlSystemsBase/src/plotting.jl
+++ b/lib/ControlSystemsBase/src/plotting.jl
@@ -768,9 +768,9 @@ pzmap
         if isdiscrete(system)
             θ = range(0,stop=2π,length=100)
             S,C = sin.(θ),cos.(θ)
-            seriestype := :path
             @series begin
-                linecolor := :black
+                seriestype := :shape
+                fillalpha := 0
                 C,S
             end
         end

--- a/lib/ControlSystemsBase/src/plotting.jl
+++ b/lib/ControlSystemsBase/src/plotting.jl
@@ -766,11 +766,10 @@ pzmap
         end
 
         if isdiscrete(system)
-            θ = range(0,stop=2π,length=100)
-            S,C = sin.(θ),cos.(θ)
             @series begin
                 seriestype := :shape
                 fillalpha := 0
+                Plots.partialcircle(0, 2π, 100)
                 C,S
             end
         end


### PR DESCRIPTION
Instead of setting the line color of the unit circle in `pzmap` explicitely (to `:black`), the foreground color defined in the plot attributes is used to plot the unit circle. This is useful, when using dark themes for instance.