### PR TITLE
handle breaking change in Polynomials

### DIFF
--- a/lib/ControlSystemsBase/Project.toml
+++ b/lib/ControlSystemsBase/Project.toml
@@ -2,7 +2,7 @@ name = "ControlSystemsBase"
 uuid = "aaaaaaaa-a6ca-5380-bf3e-84a91bcd477e"
 authors = ["Dept. Automatic Control, Lund University"]
 repo = "https://github.com/JuliaControl/ControlSystemsBase.jl.git"
-version = "1.4.1"
+version = "1.4.2"
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"

--- a/lib/ControlSystemsBase/src/types/conversion.jl
+++ b/lib/ControlSystemsBase/src/types/conversion.jl
@@ -137,7 +137,7 @@ function siso_tf_to_ss(T::Type, f::SisoRational)
     N = length(den) - 1 # The order of the rational function f
 
     # Get numerator coefficient of the same order as the denominator
-    bN = length(num) == N+1 ? num[1] : zero(num[1])
+    bN = length(num) == N+1 ? num[1] : zero(eltype(num))
 
     @views if N == 0 #|| num == zero(Polynomial{T})
         A = zeros(T, 0, 0)

--- a/lib/ControlSystemsBase/test/test_conversion.jl
+++ b/lib/ControlSystemsBase/test/test_conversion.jl
@@ -176,4 +176,9 @@ s3,s4 = promote(s1,s2)
 @test s3 == s4 == s2
 @test typeof(s3) == typeof(s4) == typeof(s2)
 
+# https://github.com/JuliaControl/ControlSystems.jl/issues/828
+mytf = [tf(1,[1,1]) tf(0); tf(0) tf(1,[1,1])]
+myss = ss(mytf)
+@test myss == ss([-1 0; 0 -1],[1 0; 0 1],[1 0; 0 1],[0 0; 0 0])
+
 end


### PR DESCRIPTION
closes #828

the breaking change was introduced by 
- https://github.com/JuliaMath/Polynomials.jl/pull/487

more specifically, 
> Uses T[] for the coefficients of a 0 polynomial, not T[0], which requires zero(T). This led to some fixes on evaluation and changed some tests