### PR TITLE
better error message for improper delay conversion

### DIFF
--- a/lib/ControlSystemsBase/src/types/DelayLtiSystem.jl
+++ b/lib/ControlSystemsBase/src/types/DelayLtiSystem.jl
@@ -59,6 +59,10 @@ function Base.convert(::Type{DelayLtiSystem{T1,S}}, d::T2) where {T1,T2 <: Abstr
 end
 
 function Base.convert(::Type{DelayLtiSystem{T,S}}, sys::TransferFunction{TE}) where {T,S,TE}
+    if issiso(sys) && length(numvec(sys.matrix[1,1])) > length(denvec(sys.matrix[1,1]))
+        error("The transfer function is not proper and can not be converted to a DelayLtiSystem type. If you tried to form the system `exp(sL) * B / A` where `B / A` is proper, add parenthesis to make it `exp(sL) * (B / A)`.")
+    end
+       
     DelayLtiSystem{T,S}(convert(StateSpace{TE, T}, sys))
 end
 # Catch convertsion between T

--- a/lib/ControlSystemsBase/test/test_conversion.jl
+++ b/lib/ControlSystemsBase/test/test_conversion.jl
@@ -62,6 +62,9 @@ H3 = zpk([(-1+im*sqrt(79))/8, (-1-im*sqrt(79))/8], [-3/2], 2)
 @test zpk(G3) ≈ H3 rtol=1e-15
 @test zpk(H3) == H3
 
+@test_throws ErrorException delay(5)*((s+1))/((s+2)*(s+0.5))
+@test_throws ErrorException delay(5)*zpk((s+1))/zpk((s+2)*(s+0.5))
+
 # Test complex 1
 A = [1.0 + im 1; 0 -2-3im]
 B = [0;2]

--- a/lib/ControlSystemsBase/test/test_conversion.jl
+++ b/lib/ControlSystemsBase/test/test_conversion.jl
@@ -62,6 +62,7 @@ H3 = zpk([(-1+im*sqrt(79))/8, (-1-im*sqrt(79))/8], [-3/2], 2)
 @test zpk(G3) ≈ H3 rtol=1e-15
 @test zpk(H3) == H3
 
+s = tf("s")
 @test_throws ErrorException delay(5)*((s+1))/((s+2)*(s+0.5))
 @test_throws ErrorException delay(5)*zpk((s+1))/zpk((s+2)*(s+0.5))
 


### PR DESCRIPTION

```julia
julia> delay(5)*((s+1))/((s+2)*(s+0.5))
ERROR: The transfer function is not proper and can not be converted to a DelayLtiSystem type. If you tried to form the system `exp(sL) * B / A` where `B / A` is proper, add parenthesis to make it `exp(sL) * (B / A)`.
```

Ref #830 