### PR TITLE
add option to design observers with direct term

### DIFF
--- a/lib/ControlSystemsBase/ext/ControlSystemsBaseImplicitDifferentiationExt.jl
+++ b/lib/ControlSystemsBase/ext/ControlSystemsBaseImplicitDifferentiationExt.jl
@@ -116,7 +116,7 @@ To make the Kalman solver work with dual numbers, make sure that the `R` matrix 
 function kalman(::DiscreteType, A, C, Q, R::AbstractMatrix{<:Dual})
     X = are(Discrete, A', C', Q, R)
     CX = C*X
-    (R+CX*B)\(CX*A)
+    (R+CX*C')\(CX*A')
 end
 
 

--- a/lib/ControlSystemsBase/src/ControlSystemsBase.jl
+++ b/lib/ControlSystemsBase/src/ControlSystemsBase.jl
@@ -45,6 +45,7 @@ export  LTISystem,
         time_scale,
         innovation_form,
         observer_predictor,
+        observer_filter,
         observer_controller,
         # Stability Analysis
         isstable,

--- a/lib/ControlSystemsBase/src/discrete.jl
+++ b/lib/ControlSystemsBase/src/discrete.jl
@@ -152,7 +152,7 @@ rstc(args...)=rst(args..., ;cont=true)
 
 Polynomial synthesis in discrete time.
 
-Polynomial synthesis according to CCS ch 10 to
+Polynomial synthesis according to "Computer-Controlled Systems" ch 10 to
 design a controller ``R(q) u(k) = T(q) r(k) - S(q) y(k)``
 
 Inputs:

--- a/lib/ControlSystemsBase/src/matrix_comps.jl
+++ b/lib/ControlSystemsBase/src/matrix_comps.jl
@@ -808,7 +808,7 @@ such that `feedback(sys, cont)` produces a closed-loop system with eigenvalues g
 
 This controller does not have a direct term, and corresponds to state feedback operating on state estimated by [`observer_predictor`](@ref). Use this form if the computed control signal is applied at the next sampling instant, or with an otherwise large delay in relation to the measurement fed into the controller.
 
-Ref: CCS Eq 4.37
+Ref: "Computer-Controlled Systems" Eq 4.37
 
 # If `direct = true`
 Return the observer_controller `cont` that is given by
@@ -819,7 +819,7 @@ This controller has a direct term, and corresponds to state feedback operating o
 !!! note
     To use this formulation, the observer gain `K` should have been designed for the pair `(A, CA)` rather than `(A, C)`. To do this, pass `direct = true` when calling [`place`](@ref) or [`kalman`](@ref).
 
-Ref: Ref: CCS pp 140 and CCS pp 162 prob 4.7
+Ref: Ref: "Computer-Controlled Systems" pp 140 and "Computer-Controlled Systems" pp 162 prob 4.7
 
 # Arguments:
 - `sys`: Model of system
@@ -861,7 +861,7 @@ The observer filter is equivalent to the [`observer_predictor`](@ref) for contin
 !!! note
     To use this formulation, the observer gain `K` should have been designed for the pair `(A, CA)` rather than `(A, C)`. To do this, pass `direct = true` when calling [`place`](@ref) or [`kalman`](@ref).
 
-Ref: CCS Eq 4.32
+Ref: "Computer-Controlled Systems" Eq 4.32
 """
 function observer_filter(sys::AbstractStateSpace{<:Discrete}, K::AbstractMatrix; output_state = false)
     A,B,C,D = ssdata(sys)

--- a/lib/ControlSystemsBase/src/synthesis.jl
+++ b/lib/ControlSystemsBase/src/synthesis.jl
@@ -78,7 +78,7 @@ end
 
 Calculate the optimal Kalman gain.
 
-If `direct = true`, the observer gain is computed for the pair `(A, CA)` instead of `(A,C)`. This option is intended to be used together with the option `direct = true` to [`observer_controller`](@ref). Ref: CCS pp 140.
+If `direct = true`, the observer gain is computed for the pair `(A, CA)` instead of `(A,C)`. This option is intended to be used together with the option `direct = true` to [`observer_controller`](@ref). Ref: "Computer-Controlled Systems" pp 140.
 
 The `args...; kwargs...` are sent to the Riccati solver, allowing specification of cross-covariance etc. See `?MatrixEquations.arec/ared` for more help.
 """
@@ -116,7 +116,7 @@ If `direct = true` and `opt = :o`, the the observer gain `K` is calculated such 
 
 Note: only apply `direct = true` to discrete-time systems.
 
-Ref: CCS pp 140.
+Ref: "Computer-Controlled Systems" pp 140.
 
 Uses Ackermann's formula for SISO systems and [`place_knvd`](@ref) for MIMO systems. 
 

--- a/lib/ControlSystemsBase/src/synthesis.jl
+++ b/lib/ControlSystemsBase/src/synthesis.jl
@@ -152,7 +152,7 @@ function place(sys::AbstractStateSpace, p, opt=:c; direct = false, kwargs...)
     if opt === :c
         return place(sys.A, sys.B, p, opt; kwargs...)
     elseif opt === :o
-        iscontinuous(sys) && error("direct = true only applies to discrete-time systems")
+        iscontinuous(sys) && direct && error("direct = true only applies to discrete-time systems")
         return place(sys.A, sys.C, p, opt; direct, kwargs...)
     else
         error("third argument must be :c or :o")

--- a/lib/ControlSystemsBase/test/test_matrix_comps.jl
+++ b/lib/ControlSystemsBase/test/test_matrix_comps.jl
@@ -234,28 +234,6 @@ cont = observer_controller(sys, L, K, direct=true)
 syscl = feedback(sys, cont)
 @test isstable(syscl)
 
-pcl = poles(syscl)
-A,B,C,D = ssdata(sys)
-allpoles = [
-    eigvals(A-B*L)
-    eigvals(A-K*C)
-]
-@test sort(pcl, by=LinearAlgebra.eigsortby) ≈ sort(allpoles, by=LinearAlgebra.eigsortby) 
-@test cont.B == K
-
-## Test time scaling
-for balanced in [true, false]
-    sys = ssrand(1,1,5);
-    t = 0:0.1:50
-    a = 10
-
-    Gs = tf(1, [1e-6, 1]) # micro-second time scale modeled in seconds
-    Gms = time_scale(Gs, 1e-6; balanced) # Change to micro-second time scale
-    @test Gms == tf(1, [1, 1])
-end
-
-
-
 # Test observer_controller discrete with pole placement
 Ts = 0.01
 sys = ssrand(2,3,4; Ts, proper=true)
@@ -291,6 +269,17 @@ allpoles = [
     p; p2
 ]
 @test sort(pcl, by=real) ≈ sort(allpoles, by=real) rtol=1e-3
+
+## Test time scaling
+for balanced in [true, false]
+    sys = ssrand(1,1,5);
+    t = 0:0.1:50
+    a = 10
+
+    Gs = tf(1, [1e-6, 1]) # micro-second time scale modeled in seconds
+    Gms = time_scale(Gs, 1e-6; balanced) # Change to micro-second time scale
+    @test Gms == tf(1, [1, 1])
+end
 
 
 

--- a/lib/ControlSystemsBase/test/test_matrix_comps.jl
+++ b/lib/ControlSystemsBase/test/test_matrix_comps.jl
@@ -118,6 +118,8 @@ K = kalman(sys, I(2), I(1))
 @test sysp.A == sys.A-K*sys.C
 @test sysp.B == [sys.B-K*sys.D K]
 
+@test sysp == observer_filter(sys, K) # Equivalent for continuous-time systems
+
 # test longer prediction horizons
 
 # With K=0, y should have no influence
@@ -191,6 +193,7 @@ R2 = I(2)
 L = lqr(sys, Q1, Q2)
 K = kalman(sys, R1, R2)
 cont = observer_controller(sys, L, K)
+@test iszero(cont.D)
 syscl = feedback(sys, cont)
 
 pcl = poles(syscl)
@@ -215,6 +218,82 @@ end
 
 
 
+# Test observer_controller discrete with LQG
+Ts = 0.01
+sys = ssrand(2,3,4; Ts, proper=true)
+Q1 = I(4)
+Q2 = I(3)
+R1 = I(4)
+R2 = I(2)
+@test are(sys, Q1, Q2) == are(Discrete, sys.A, sys.B, Q1, Q2)
+@test lyap(sys, Q1) == lyap(Discrete, sys.A, Q1)
+L = lqr(sys, Q1, Q2)
+K = kalman(sys, R1, R2; direct = true)
+cont = observer_controller(sys, L, K, direct=true)
+@test !iszero(cont.D)
+syscl = feedback(sys, cont)
+@test isstable(syscl)
+
+pcl = poles(syscl)
+A,B,C,D = ssdata(sys)
+allpoles = [
+    eigvals(A-B*L)
+    eigvals(A-K*C)
+]
+@test sort(pcl, by=LinearAlgebra.eigsortby) ≈ sort(allpoles, by=LinearAlgebra.eigsortby) 
+@test cont.B == K
+
+## Test time scaling
+for balanced in [true, false]
+    sys = ssrand(1,1,5);
+    t = 0:0.1:50
+    a = 10
+
+    Gs = tf(1, [1e-6, 1]) # micro-second time scale modeled in seconds
+    Gms = time_scale(Gs, 1e-6; balanced) # Change to micro-second time scale
+    @test Gms == tf(1, [1, 1])
+end
+
+
+
+# Test observer_controller discrete with pole placement
+Ts = 0.01
+sys = ssrand(2,3,4; Ts, proper=true)
+p = exp.(Ts .* [-10, -20, -30, -40])
+p2 = exp.(2*Ts .* [-10, -20, -30, -40])
+L = place(sys, p, :c)
+K = place(sys, p2, :o)
+cont = observer_controller(sys, L, K)
+@test iszero(cont.D)
+syscl = feedback(sys, cont)
+
+pcl = poles(syscl)
+A,B,C,D = ssdata(sys)
+allpoles = [
+    eigvals(A-B*L)
+    eigvals(A-K*C)
+]
+@test sort(pcl, by=real) ≈ (sort(allpoles, by=real)) rtol=1e-3
+@test cont.B == K
+
+
+Kd = place(sys, p2, :o; direct = true) 
+@test Kd == place(sys.A', (sys.C*sys.A)', p2)'
+cont_direct = observer_controller(sys, L, Kd, direct=true)
+@test !iszero(cont_direct.D)
+
+syscld = feedback(sys, cont_direct)
+@test isstable(syscld)
+
+pcl = poles(syscld)
+A,B,C,D = ssdata(sys)
+allpoles = [
+    p; p2
+]
+@test sort(pcl, by=real) ≈ sort(allpoles, by=real) rtol=1e-3
+
+
+
 ## Test balancing with Duals
 using ForwardDiff: Dual
 A = Dual.([-0.21 0.2; 0.2 -0.21])
@@ -228,3 +307,4 @@ sysb,T = ControlSystemsBase.balance_statespace(sys)
 @test similarity_transform(sysb, T) ≈ sys
 
 end 
+


### PR DESCRIPTION
This applies to several functions
- `kalman`
- `observer_controller`
- `place`
- `observer_filter` (new function in this PR)

This PR also adds the option to let observers output the state estimate rather than the output estimate.

The reference CCS refers to Computer Controlled Systems by Åström and Wittenmark