### PR TITLE
remove automatic field propagation from `balance_statespace`

### DIFF
--- a/lib/ControlSystemsBase/src/plotting.jl
+++ b/lib/ControlSystemsBase/src/plotting.jl
@@ -288,9 +288,11 @@ end
 
     for (si,s) = enumerate(systems)
         if balance
-            s = balance_statespace(s)[1]
+            sbal = balance_statespace(s)[1]
+        else
+            sbal = s
         end
-        mag, phase = bode(s, w)[1:2]
+        mag, phase = bode(sbal, w)[1:2]
         if _PlotScale == "dB" # Set by setPlotScale(str) globally
             mag = 20*log10.(mag)
         end

--- a/lib/ControlSystemsBase/src/types/conversion.jl
+++ b/lib/ControlSystemsBase/src/types/conversion.jl
@@ -189,11 +189,7 @@ end
 
 function balance_statespace(sys::S, perm::Bool=false) where S <: AbstractStateSpace
     A, B, C, T = balance_statespace(sys.A,sys.B,sys.C, perm)
-    if hasfield(S, :sys)
-        basetype(S)(ss(A,B,C,sys.D), ntuple(i->getfield(sys, i+1), fieldcount(S)-1)...), T
-    else
-        basetype(S)(A,B,C,sys.D, ntuple(i->getfield(sys, i+4), fieldcount(S)-4)...), T
-    end
+    ss(A,B,C,sys.D,sys.timeevol), T
 end
 
 # Method that might fail for some exotic types, such as TrackedArrays

--- a/lib/ControlSystemsBase/test/test_matrix_comps.jl
+++ b/lib/ControlSystemsBase/test/test_matrix_comps.jl
@@ -21,6 +21,8 @@ Ab,Bb,Cb,T = ControlSystemsBase.balance_statespace(A,B,C)
 @test sysb.A ≈ Ab
 @test similarity_transform(sysb, T) ≈ sys
 
+@test dcgain(sys) ≈ dcgain(sysb)
+
 
 U = svd(randn(2,2)).U
 syst = similarity_transform(sys, U, unitary = true)
@@ -28,6 +30,10 @@ Ab,Bb,Cb,Db = ssdata(syst)
 @test Ab ≈ U'A*U
 @test Bb ≈ U'B
 @test Cb ≈ C*U
+
+sysd = ss(A,B,C,D,1)
+sysdb, _ = balance_statespace(sysd)
+@test dcgain(sysd) ≈ dcgain(sysdb)
 
 
 @test ControlSystemsBase.balance_transform(A,B,C) ≈ ControlSystemsBase.balance_transform(sys)


### PR DESCRIPTION
The reason is that many abstract statespace types have fields that are affected by the balancing, and the automatic forwarding of those fields without application of the balancing led to incorrect answers. The proper way of handling this is for each type to implement their own method of `balance_statespace` if the additional fields are required.