### PR TITLE
[doc] Add the PBH test in `obsv` and `ctrb` docstring

### DIFF
--- a/lib/ControlSystemsBase/src/matrix_comps.jl
+++ b/lib/ControlSystemsBase/src/matrix_comps.jl
@@ -124,7 +124,8 @@ Compute the observability matrix with `n` rows for the system described by `(A, 
 Note that checking for observability by computing the rank from `obsv` is
 not the most numerically accurate way, a better method for stable A is checking if
 `gram(sys, :o)` is positive definite. Another method is the Popov-Belevitch-Hautus 
-(PBH) test: `all(map(λ->rank([λ * I - A; C]) == size(A, 1), eigvals(A)))`.
+(PBH) test: `all(map(λ->rank([λ * I - A; C]; rtol) == size(A, 1), eigvals(A)))` and
+`rtol=size(A, 1)*eps(promote_type(eltype.((A, C))...))` as an appropriate tolerance.
 """
 function obsv(A::AbstractMatrix, C::AbstractMatrix, n::Int = size(A,1))
     T = promote_type(eltype(A), eltype(C))
@@ -153,7 +154,9 @@ Note that checking for controllability by computing the rank from
 `ctrb` is not the most numerically accurate way, a better method for
 stable A is checking if `gram(sys, :c)` is positive definite. Another 
 method is the Popov-Belevitch-Hautus (PBH) test: 
-`all(map(λ->rank([λ*I - A; B]) == size(A, 1), eigvals(A)))`.
+`all(map(λ->rank([λ*I - A; B]) == size(A, 1), eigvals(A)))` and
+`rtol=size(A, 1)*eps(promote_type(eltype.((A, C))...))` as an appropriate 
+tolerance.
 """
 function ctrb(A::AbstractMatrix, B::AbstractVecOrMat)
     T = promote_type(eltype(A), eltype(B))

--- a/lib/ControlSystemsBase/src/matrix_comps.jl
+++ b/lib/ControlSystemsBase/src/matrix_comps.jl
@@ -122,8 +122,9 @@ end
 Compute the observability matrix with `n` rows for the system described by `(A, C)` or `sys`. Providing the optional `n > sys.nx` returns an extended observability matrix.
 
 Note that checking for observability by computing the rank from `obsv` is
-not the most numerically accurate way, a better method is checking if
-`gram(sys, :o)` is positive definite.
+not the most numerically accurate way, a better method for stable A is checking if
+`gram(sys, :o)` is positive definite. Another method is the Popov-Belevitch-Hautus 
+(PBH) test: `all(map(λ->rank([λ * I - A; C]) == size(A, 1), eigvals(A)))`.
 """
 function obsv(A::AbstractMatrix, C::AbstractMatrix, n::Int = size(A,1))
     T = promote_type(eltype(A), eltype(C))
@@ -149,8 +150,10 @@ Compute the controllability matrix for the system described by `(A, B)` or
 `sys`.
 
 Note that checking for controllability by computing the rank from
-`ctrb` is not the most numerically accurate way, a better method is
-checking if `gram(sys, :c)` is positive definite.
+`ctrb` is not the most numerically accurate way, a better method for
+stable A is checking if `gram(sys, :c)` is positive definite. Another 
+method is the Popov-Belevitch-Hautus (PBH) test: 
+`all(map(λ->rank([λ*I - A; B]) == size(A, 1), eigvals(A)))`.
 """
 function ctrb(A::AbstractMatrix, B::AbstractVecOrMat)
     T = promote_type(eltype(A), eltype(B))


### PR DESCRIPTION
I suggest to add the code for the PBH tests in the documentation to help the users.

While writing my package, I struggle to find a simple method to assess the observability of a linear system that is both numerically robust and universal, that is, also works on unstable systems (the gramian is only defined for stable A). There is many complex methods from what I found in the literature. A simple method that I just learned the existence is the [PBH Test](https://en.wikipedia.org/wiki/Hautus_lemma). That's what MATLAB uses internally to quickly check observability.

Keep up the good work!

Francis