### PR TITLE
Convert pid parameters to :parallel

### DIFF
--- a/lib/ControlSystemsBase/src/pid_design.jl
+++ b/lib/ControlSystemsBase/src/pid_design.jl
@@ -520,7 +520,7 @@ The `form` can be chosen as one of the following
 """
 function convert_pidparams_to_standard(param_p, param_i, param_d, form::Symbol)
     if form === :standard
-        return (param_p, param_i, param_d)
+        return @. (param_p, param_i, param_d)
     elseif form === :series
         return @. (
             param_p * (param_i + param_d) / param_i,
@@ -546,7 +546,7 @@ The `form` can be chosen as one of the following
 """
 function convert_pidparams_to_parallel(param_p, param_i, param_d, form::Symbol)
     if form === :parallel
-        return (param_p, param_i, param_d)
+        return @. (param_p, param_i, param_d)
     elseif form === :series
         # param_i = 0 would result in division by zero, but typically indicates that the user wants no integral action
         param_i == 0 && return @. param_p * (1, 0, param_d)
@@ -572,7 +572,7 @@ The `form` can be chosen as one of the following
 """
 function convert_pidparams_from_standard(Kp, Ti, Td, form::Symbol)
     if form === :standard
-        return Kp, Ti, Td
+        return @. (Kp, Ti, Td)
     elseif form === :series
         Δ = Ti * (Ti - 4 * Td)
         Δ < 0 && throw(DomainError("The condition Ti^2 ≥ 4Td*Ti is not satisfied: the PID parameters cannot be converted to series form"))
@@ -600,7 +600,7 @@ The `form` can be chosen as one of the following
 """
 function convert_pidparams_from_parallel(Kp, Ki, Kd, to::Symbol)
     if to === :parallel
-        return (Kp, Ki, Kd)
+        return @. (Kp, Ki, Kd)
     elseif to === :series
         Ki == 0 && return @. Kp * (1, 0, Kd)
         Δ = Kp^2-4Ki*Kd
@@ -610,8 +610,8 @@ function convert_pidparams_from_parallel(Kp, Ki, Kd, to::Symbol)
         return @. ((Kp - sqrtΔ)/2, (Kp - sqrtΔ)/(2Ki), (Kp + sqrtΔ)/(2Ki))
     elseif to === :standard
         Kp == 0 && throw(DomainError("Cannot convert to standard form when Kp=0"))
-        Ki == 0 && return (Kp, Inf, Kd / Kp)
-        return (Kp, Kp / Ki, Kd / Kp)
+        Ki == 0 && return @. (Kp, Inf, Kd / Kp)
+        return @. (Kp, Kp / Ki, Kd / Kp)
     else
         throw(ArgumentError("form $(form) not supported."))
     end

--- a/lib/ControlSystemsBase/test/test_pid_design.jl
+++ b/lib/ControlSystemsBase/test/test_pid_design.jl
@@ -84,6 +84,16 @@ C, Kp, Ti = placePI(P, 2, 0.7; form=:standard)
 @test [Kp, Ti] ≈ [9/5, 9/20]
 
 # Test internal functions convert_pidparams*
+# Standard
+params = (2, 3, 0.5)
+parallel_params = ControlSystemsBase.convert_pidparams_from_standard(params..., :parallel)
+@test parallel_params == (2, 2/3, 1)
+@test ControlSystemsBase.convert_pidparams_to_standard(parallel_params..., :parallel) == params
+series_params = ControlSystemsBase.convert_pidparams_from_standard(params..., :series)
+@test series_params == ((3-sqrt(3))/3, (3-sqrt(3))/2, (3+sqrt(3))/2)
+@test ControlSystemsBase.convert_pidparams_to_standard(series_params..., :series) == params
+
+# Parallel
 params = (4, 3, 0.5)
 standard_params = ControlSystemsBase.convert_pidparams_from_parallel(params..., :standard)
 @test standard_params == (4, 4/3, 0.5/4)

--- a/lib/ControlSystemsBase/test/test_pid_design.jl
+++ b/lib/ControlSystemsBase/test/test_pid_design.jl
@@ -1,5 +1,7 @@
 @testset "test_pid_design" begin
 
+CSB = ControlSystemsBase
+
 # Test gof plot and loopshaping
 P = tf(1,[1,1])^4
 gangoffourplot(P,tf(1))
@@ -15,6 +17,9 @@ C, kp, ki = loopshapingPI(P, ωp, phasemargin=60, form=:parallel, doplot=true)
 @test pid(1.0, Inf, 1) == tf(1) + tf([1, 0], [1])
 @test pid(1.0, 0, 1) == tf(1) + tf([1, 0], [1])
 @test pid(0.0, 1, 1; form=:parallel) == tf(0) + tf(1,[1,0]) + tf([1,0],[1])
+@test_throws DomainError CSB.convert_pidparams_from_parallel(2, 3, 0.5, :series)
+@test_throws DomainError CSB.convert_pidparams_from_parallel(0, 3, 0.5, :standard)
+@test_throws DomainError CSB.convert_pidparams_from_standard(2, 1, 0.5, :series)
 # ss
 @test tf(pid(1.0, 1, 0; state_space=true)) == tf(1) + tf(1,[1,0])
 

--- a/lib/ControlSystemsBase/test/test_pid_design.jl
+++ b/lib/ControlSystemsBase/test/test_pid_design.jl
@@ -13,6 +13,8 @@ C, kp, ki = loopshapingPI(P, ωp, phasemargin=60, form=:parallel, doplot=true)
 # tf
 @test pid(1.0, 1, 1) == tf(1) + tf(1,[1,0]) + tf([1,0],[1])
 @test pid(1.0, Inf, 1) == tf(1) + tf([1, 0], [1])
+@test pid(1.0, 0, 1) == tf(1) + tf([1, 0], [1])
+@test pid(0.0, 1, 1; form=:parallel) == tf(0) + tf(1,[1,0]) + tf([1,0],[1])
 # ss
 @test tf(pid(1.0, 1, 0; state_space=true)) == tf(1) + tf(1,[1,0])
 
@@ -72,13 +74,13 @@ C, Kp, Ti = placePI(P, 2, 0.7; form=:standard)
 @test [Kp, Ti] ≈ [9/5, 9/20]
 
 # Test internal functions convert_pidparams*
-params = (2, 3, 0.5)
-parallel_params = ControlSystemsBase.convert_pidparams_from_standard(params..., :parallel)
-@test parallel_params == (2, 2/3, 1)
-@test ControlSystemsBase.convert_pidparams_to_standard(parallel_params..., :parallel) == params
-series_params = ControlSystemsBase.convert_pidparams_from_standard(params..., :series)
-@test series_params == ((3-sqrt(3))/3, (3-sqrt(3))/2, (3+sqrt(3))/2)
-@test ControlSystemsBase.convert_pidparams_to_standard(series_params..., :series) == params
+params = (4, 3, 0.5)
+standard_params = ControlSystemsBase.convert_pidparams_from_parallel(params..., :standard)
+@test standard_params == (4, 4/3, 0.5/4)
+@test ControlSystemsBase.convert_pidparams_to_parallel(standard_params..., :standard) == params
+series_params = ControlSystemsBase.convert_pidparams_from_parallel(params..., :series)
+@test series_params == ((4-sqrt(10))/2, (4-sqrt(10))/6, (4+sqrt(10))/6)
+@test all(ControlSystemsBase.convert_pidparams_to_parallel(series_params..., :series) .≈ params)
 
 # lead lag link
 a = 1

--- a/lib/ControlSystemsBase/test/test_pid_design.jl
+++ b/lib/ControlSystemsBase/test/test_pid_design.jl
@@ -17,11 +17,16 @@ C, kp, ki = loopshapingPI(P, ωp, phasemargin=60, form=:parallel, doplot=true)
 @test pid(1.0, Inf, 1) == tf(1) + tf([1, 0], [1])
 @test pid(1.0, 0, 1) == tf(1) + tf([1, 0], [1])
 @test pid(0.0, 1, 1; form=:parallel) == tf(0) + tf(1,[1,0]) + tf([1,0],[1])
+@test pid(1.0, 2, 3; Tf=2) == tf([3,1,0.5], [2,2,1,0])
+@test all(CSB.convert_pidparams_from_standard(CSB.convert_pidparams_from_parallel(1, 2, 3, :standard)...,
+                                                  :parallel) .≈ (1,2,3))
 @test_throws DomainError CSB.convert_pidparams_from_parallel(2, 3, 0.5, :series)
 @test_throws DomainError CSB.convert_pidparams_from_parallel(0, 3, 0.5, :standard)
 @test_throws DomainError CSB.convert_pidparams_from_standard(2, 1, 0.5, :series)
 # ss
 @test tf(pid(1.0, 1, 0; state_space=true)) == tf(1) + tf(1,[1,0])
+@test tf(pid(0.0, 2, 3; form=:parallel, state_space=true, Tf=2)) == tf([3,0,2], [2, 2, 1, 0])
+@test tf(pid(1.0, 2, 3; state_space=true, Tf=2)) == tf([3, 1, 0.5], [2, 2, 1, 0])
 
 # Discrete
 @test_throws ArgumentError pid(1.0, 1, 1, Ts=0.1)


### PR DESCRIPTION
Using standard fails when KP=0.