### PR TITLE
handle proper quotient of proper statespace systems

### DIFF
--- a/lib/ControlSystemsBase/src/discrete.jl
+++ b/lib/ControlSystemsBase/src/discrete.jl
@@ -21,7 +21,7 @@ ZoH sampling is exact for linear systems with piece-wise constant inputs (step i
 
 FoH sampling is exact for linear systems with piece-wise linear inputs (ramp invariant), this is a good choice for simulation of systems with smooth continuous inputs.
 
-To approximate the behavior of a continuous-time system well in the frequency domain, the `:tustin` (trapezoidal / bilinear) method may be most appropriate. In this case, the pre-warping argument can be used to ensure that the frequency response of the discrete-time system matches the continuous-time system at a given frequency. The tustin transformation alters the meaning of the state components, while ZoH and FoH preserve the meaning of the state components. The Tustin method is commonly used to discretize a continuous-tiem controller.
+To approximate the behavior of a continuous-time system well in the frequency domain, the `:tustin` (trapezoidal / bilinear) method may be most appropriate. In this case, the pre-warping argument can be used to ensure that the frequency response of the discrete-time system matches the continuous-time system at a given frequency. The tustin transformation alters the meaning of the state components, while ZoH and FoH preserve the meaning of the state components. The Tustin method is commonly used to discretize a continuous-time controller.
 
 The forward-Euler method generally requires the sample time to be very small
 relative to the time constants of the system, and its use is generally discouraged.
@@ -99,8 +99,8 @@ function d2c(sys::AbstractStateSpace{<:Discrete}, method::Symbol=:zoh; w_prewarp
     ny, nu = size(sys)
     nx = nstates(sys)
     if method === :zoh
-        M = log([A  B;
-            zeros(nu, nx) I])./sys.Ts
+        M = log(Matrix([A  B;
+            zeros(nu, nx) I]))./sys.Ts
         Ac = M[1:nx, 1:nx]
         Bc = M[1:nx, nx+1:nx+nu]
         if eltype(A) <: Real

--- a/lib/ControlSystemsBase/src/types/StateSpace.jl
+++ b/lib/ControlSystemsBase/src/types/StateSpace.jl
@@ -431,10 +431,11 @@ end
 function /(n::Number, sys::ST) where ST <: AbstractStateSpace
     # Ensure s.D is invertible
     A, B, C, D = ssdata(sys)
+    size(D, 1) == size(D, 2) || error("The inverted system must have the same number of inputs and outputs")
     Dinv = try
         inv(D)
     catch
-        error("D isn't invertible")
+        error("D isn't invertible. If you are trying to form a quotient between two systems `N(s) / D(s)` where the quotient is proper but the inverse of `D(s)` isn't, consider calling `N / D` instead of `N * inv(D)")
     end
     return basetype(ST)(A - B*Dinv*C, B*Dinv, -n*Dinv*C, n*Dinv, sys.timeevol)
 end

--- a/lib/ControlSystemsBase/test/test_statespace.jl
+++ b/lib/ControlSystemsBase/test/test_statespace.jl
@@ -159,10 +159,17 @@
 
         # Division
         @test 1/C_222_d == SS([-6 -3; 2 -11],[1 0; 0 2],[-1 0; -0 -1],[1 -0; 0 1])
-        @test C_221/C_222_d == SS([-5 -3 -1 0; 2 -9 -0 -2; 0 0 -6 -3;
-        0 0 2 -11],[1 0; 0 2; 1 0; 0 2],[1 0 0 0],[0 0])
+        @test hinfnorm((C_221/C_222_d) - SS([-5 -3 -1 0; 2 -9 -0 -2; 0 0 -6 -3;
+        0 0 2 -11],[1 0; 0 2; 1 0; 0 2],[1 0 0 0],[0 0]))[1] < 1e-10
         @test 1/D_222_d == SS([-0.8 -0.8; -0.8 -1.93],[1 0; 0 2],[-1 0; -0 -1],
         [1 -0; 0 1],0.005)
+
+        # Division when denominator inverse is non-proper but quotient is proper
+        G1 = tf([1], [1, 1])
+        G2 = tf([1], [1, 1, 1])
+        G1s = ss(G1)
+        G2s = ss(G2)
+        @test tf(G2s / G1s) ≈ G2 / G1
 
         fsys = ss(1,1,1,0)/3 # Int becomes FLoat after division
         @test fsys.B[]*fsys.C[] == 1/3


### PR DESCRIPTION
The PR adds a method of `/` between two statespace systems 
$$G_2 G_1^{-1}$$
that handles situations in which $G_1^{-1}$ s non-proper and naive inversion fails, but the quotient $G_2 G_1^{-1}$ is proper and can be represented as a statespace system.

The intermediate result is a descriptor system with non-identity and singular mass matrix `Ei` which is immediately simplified using `MatrixPencils.lsminreal` into a descriptor system with invertible mass matrix (if possible). This system is in turn simplified to have unit mass matrix. If the quotient isn't proper, at least one of the steps above will fail and throw an error `The system sys2 is not invertible`.

The call to `lsminreal` will generally lead to a smaller realization compared to what was returned before. This is the reason the test 
```julia
C_221/C_222_d == SS([-5 -3 -1 0; 2 -9 -0 -2; 0 0 -6 -3;
        0 0 2 -11],[1 0; 0 2; 1 0; 0 2],[1 0 0 0],[0 0])
```
was changed to compare the H-infnorm, we now return a second-order system instead of 4:th order.