### PR TITLE
Update `minreal` docstring

### DIFF
--- a/lib/ControlSystemsBase/src/types/StateSpace.jl
+++ b/lib/ControlSystemsBase/src/types/StateSpace.jl
@@ -586,7 +586,7 @@ end
 
 
 """
-    minreal(sys::T; fast=false, kwargs...)
+    minreal(sys::StateSpace; fast=false, kwargs...)
 
 Minimal realisation algorithm from P. Van Dooreen, The generalized eigenstructure problem in linear system theory, IEEE Transactions on Automatic Control
 


### PR DESCRIPTION
Replace type `T` by `StateSpace` in `minreal`  method docstring for state space systems

Could be also more precise with `AbstractStateSpace`