### PR TITLE
add tools for counting multiple eigvals and adjust bode phase start

### DIFF
--- a/lib/ControlSystemsBase/src/plotting.jl
+++ b/lib/ControlSystemsBase/src/plotting.jl
@@ -329,7 +329,7 @@ end
                 end
                 plotphase || continue
 
-                if adjust_phase_start == true
+                if adjust_phase_start == true && isrational(sbal)
                     intexcess = integrator_excess(sbal)
                     if intexcess != 0
                         # Snap phase so that it starts at -90*intexcess

--- a/lib/ControlSystemsBase/src/simplification.jl
+++ b/lib/ControlSystemsBase/src/simplification.jl
@@ -47,7 +47,11 @@ function struct_ctrb_states(A::AbstractVecOrMat, B::AbstractVecOrMat)
     # UInt16 can only store up to 65535, so if A is completely dense and of size larger than 65535, the computations below might overflow. This is exceedingly unlikely though.
     bitA = UInt16.(.!iszero.(A)) # Convert to Int because multiplying with a bit matrix is slow
     x = vec(any(B .!= 0, dims=2)) # index vector indicating states that have been affected by input
-    xi = bitA * x
+    if A isa SMatrix
+        xi = Vector(bitA * x) # To aboid setindex! error below
+    else
+        xi = bitA * x
+    end
     xi2 = similar(xi)
     @. xi = (xi != false) | !iszero(x)
     for i = 2:size(A, 1) # apply A nx times, similar to controllability matrix

--- a/lib/ControlSystemsBase/src/types/Lti.jl
+++ b/lib/ControlSystemsBase/src/types/Lti.jl
@@ -1,4 +1,5 @@
 abstract type LTISystem{TE<:TimeEvolution} <: AbstractSystem end
+isrational(sys::LTISystem) = false
 +(sys1::LTISystem, sys2::LTISystem) = +(promote(sys1, sys2)...)
 -(sys1::LTISystem, sys2::LTISystem) = -(promote(sys1, sys2)...)
 function *(sys1::LTISystem, sys2::LTISystem)

--- a/lib/ControlSystemsBase/src/types/StateSpace.jl
+++ b/lib/ControlSystemsBase/src/types/StateSpace.jl
@@ -234,6 +234,7 @@ function isstable(sys::StateSpace{<:Discrete, <:ForwardDiff.Dual})
     all(abs.(ForwardDiff.value.(sys.A)) .< 1)
 end
 
+isrational(::AbstractStateSpace) = true
 
 #####################################################################
 ##                         Math Operators                          ##

--- a/lib/ControlSystemsBase/src/types/TransferFunction.jl
+++ b/lib/ControlSystemsBase/src/types/TransferFunction.jl
@@ -98,6 +98,8 @@ function isproper(G::TransferFunction)
     return all(isproper(f) for f in G.matrix)
 end
 
+isrational(::TransferFunction) = true
+
 #####################################################################
 ##                         Math Operators                          ##
 #####################################################################

--- a/lib/ControlSystemsBase/src/types/conversion.jl
+++ b/lib/ControlSystemsBase/src/types/conversion.jl
@@ -337,7 +337,13 @@ function siso_ss_to_zpk(sys, i, j)
     nx = size(A, 1)
     nz = length(z)
     k = nz == nx ? D[1] : (C*(A^(nx - nz - 1))*B)[1]
-    return z, eigvals(A), k
+    if A isa SMatrix
+        # Only hermitian matrices are diagonalizable by *StaticArrays*. Non-Hermitian matrices should be converted to `Array` first.
+        p = eigvals(Matrix(A))
+    else
+        p = eigvals(A)
+    end
+    return z, p, k
 end
 
 """

--- a/lib/ControlSystemsBase/test/test_analysis.jl
+++ b/lib/ControlSystemsBase/test/test_analysis.jl
@@ -16,6 +16,7 @@ D = [1 0;
      1 0]
 
 ex_3 = ss(A, B, C, D)
+@test ControlSystemsBase.count_integrators(ex_3) == 6
 @test tzeros(ex_3) ≈ [0.3411639019140099 + 1.161541399997252im,
                              0.3411639019140099 - 1.161541399997252im,
                              0.9999999999999999 + 0.0im,
@@ -36,12 +37,14 @@ C = [1 0 0 0 0;
 D = zeros(2, 2)
 ex_4 = ss(A, B, C, D)
 @test tzeros(ex_4) ≈ [-0.06467751189940692,-0.3680512036036696]
+@test ControlSystemsBase.count_integrators(ex_4) == 1
 
 # Example 5
 s = tf("s")
 ex_5 = 1/s^15
 @test tzeros(ex_5) == Float64[]
 @test tzeros(ss(ex_5)) == Float64[]
+@test ControlSystemsBase.count_integrators(ex_5) == 15
 
 # Example 6
 A = [2 -1 0;
@@ -52,6 +55,7 @@ C = [0 -1 0]
 D = [0]
 ex_6 = ss(A, B, C, D)
 @test tzeros(ex_6) == Float64[]
+@test ControlSystemsBase.count_integrators(ex_6) == 2
 
 @test ss(A, [0 0 1]', C, D) == ex_6
 
@@ -72,6 +76,7 @@ D = [0]
 ex_8 = ss(A, B, C, D)
 # TODO : there may be a way to improve the precision of this example.
 @test tzeros(ex_8) ≈ [-1.0, -1.0] atol=1e-7
+@test ControlSystemsBase.count_integrators(ex_8) == 0
 
 # Example 9
 ex_9 = (s - 20)/s^15
@@ -121,6 +126,7 @@ approxin2(el,col) = any(el.≈col)
 
 ex_12 = ss(-3, 2, 1, 2)
 @test poles(ex_12) ≈ [-3]
+@test ControlSystemsBase.count_integrators(ex_12) == 0
 
 ex_13 = ss([-1 1; 0 -1], [0; 1], [1 0], 0)
 @test poles(ex_13) ≈ [-1, -1]
@@ -306,5 +312,23 @@ gof = gangoffour(P,C)
 
 F = ssrand(2,2,2,proper=true)
 @test_nowarn gangofseven(P, C, F)
+
+
+## Approximate double integrator
+P = let
+     tempA = [
+          0.0 0.0 1.0 0.0 0.0 0.0
+          0.0 0.0 0.0 0.0 1.0 0.0
+          -400.0 400.0 -0.4 -0.0 0.4 -0.0
+          0.0 0.0 0.0 0.0 0.0 1.0
+          10.0 -11.0 0.01 1.0 -0.011 0.001
+          0.0 10.0 0.0 -10.0 0.01 -0.01
+     ]
+     tempB = [0.0 0.0; 0.0 0.0; 100.80166347371734 0.0; 0.0 0.0; 0.0 -0.001; 0.0 0.01]
+     tempC = [0.0 0.0 0.0 1.0 0.0 0.0]
+     tempD = [0.0 0.0]
+     ss(tempA, tempB, tempC, tempD)
+end
+@test ControlSystemsBase.count_integrators(P) == 2
 
 end


### PR DESCRIPTION
The Bode plot phase curve should now start at the correct phase, even when this is outside of `[-180, 180]` degrees.