### PR TITLE
Extend docstring

### DIFF
--- a/lib/ControlSystemsBase/src/types/StateSpace.jl
+++ b/lib/ControlSystemsBase/src/types/StateSpace.jl
@@ -214,7 +214,7 @@ HeteroStateSpace(sys::LTISystem) = convert(HeteroStateSpace, sys)
 """
     A, B, C, D = ssdata(sys)
 
-A destructor that outputs the statespace matrices.
+Outputs the statespace matrices of sys. The matrices are not copies: no new memory is allocated, but modifying the matrices in-place will change the behavior of sys.
 """
 ssdata(sys) = sys.A, sys.B, sys.C, sys.D
 


### PR DESCRIPTION
The docstring of `ssdata` lead me to believe that the matrices A, B, C, D were copies of those of sys. I suggest to change the documentation as in this PR to avoid confusion.