### PR TITLE
Use algorithms for poles and zeros of rational matrices from MatrixPencils.jl

### DIFF
--- a/lib/ControlSystemsBase/test/test_analysis.jl
+++ b/lib/ControlSystemsBase/test/test_analysis.jl
@@ -112,8 +112,10 @@ sys = s*(s + 1)*(s^2 + 1)*(s - 3)/((s + 1)*(s + 4)*(s - 4))
 @test tzeros(sys) ≈ [3.0, -1.0, im, -im, 0.0]
 
 ## POLE ##
-@test poles(sys) ≈ [4.0, -4.0, -1.0]
-@test poles([sys sys]) ≈ [4.0, -4.0, -1.0] # Issue #81
+@test es(poles(sys)) ≈ es([4.0, -4.0, -1.0])
+@test es(poles(sys, atol=1e-6)) ≈ es([4.0, -4.0]) # This cancels the -1 pole/zero
+@test es(poles([sys sys], atol=1e-6)) ≈ es([4.0, -4.0]) # Issue #81
+@test poles(zpk([sys sys])) ≈ [4.0, -4.0, -1.0] # This does not cancel the -1 pole/zero
 @test poles(ex_11) ≈ eigvals(ex_11.A)
 @test poles([2/(s+1) 3/(s+2); 1/(s+1) 1/(s+1)]) ≈ [-1, -1, -2]
 
@@ -198,7 +200,7 @@ sys = s*(s + 1)*(s^2 + 1)*(s - 3)/((s + 1)*(s + 4)*(s - 4))
 
 # Example 5.5 from https://www.control.lth.se/fileadmin/control/Education/EngineeringProgram/FRTN10/2019/e05_both.pdf
 G = [1/(s+2) -1/(s+2); 1/(s+2) (s+1)/(s+2)]
-@test_broken length(poles(G)) == 1 # The tf poles don't understand the cancellations
+@test length(poles(G)) == 1 # The tf poles do understand the cancellations
 @test length(poles(ss(G, minimal=true))) == 1 # The ss version with minimal realization does
 @test length(tzeros(G)) == 0 # tzeros converts to minimal ss relalization
 @test minreal(ss(G)).A ≈ [-2]
@@ -399,3 +401,15 @@ end
 @test es(tzeros(G)) ≈ es(tzeros(big(1)G))
 
 end
+
+
+## large TF poles and zeros
+G = ssrand(2,3,4)
+Gtf = tf(G)
+
+pss  = poles(G)
+zss  = tzeros(G)
+ptf  = poles(Gtf)
+ztf  = tzeros(Gtf)
+pzpk = poles(zpk(G))
+zzpk = tzeros(zpk(G))

--- a/lib/ControlSystemsBase/test/test_discrete.jl
+++ b/lib/ControlSystemsBase/test/test_discrete.jl
@@ -140,7 +140,8 @@ p = poles(Gcl)
 # Test that all desired poles are in the closed-loop system
 @test norm(minimum(abs.((poles(tf(Bm,Am)) .- sort(p, by=imag)')), dims=2)) < 1e-6
 # Test that the observer poles are in the closed-loop system
-@test norm(minimum(abs.((poles(tf(1,Ao)) .- sort(p, by=imag)')), dims=2)) < 1e-6
+# @test norm(minimum(abs.((poles(tf(1,Ao)) .- sort(p, by=imag)')), dims=2)) < 1e-6
+@test sort(poles(tf(1,Ao)), by=LinearAlgebra.eigsortby)[2:end] ≈ sort(p, by=LinearAlgebra.eigsortby) # One pole is (correctly) cancelled in Gcl, causing the test above to fail
 
 
 pd = c2d_poly2poly(A, 0.1)

--- a/lib/ControlSystemsBase/test/test_pid_design.jl
+++ b/lib/ControlSystemsBase/test/test_pid_design.jl
@@ -52,7 +52,7 @@ Tf = 0.01
 
 # Different damping
 Ctf = pid(1,1,1, Tf=0.1, d = 1)
-@test all(p->imag(p) == 0, poles(Ctf))
+@test all(p->isapprox(imag(p), 0, atol=1e-6), poles(Ctf))
 Css = pid(1,1,1, Tf=0.1, d = 1, state_space=true)
 @test all(p->imag(p) == 0, poles(Css))
 @test tf(Css) ≈ Ctf


### PR DESCRIPTION
Add keyword arguments that are forwarded to `MatrixPencils.rmpoles` and `MatrixPencils.rmzeros`. This makes the poles and tzeros functions understand cancellations, it also makes the computations a bit faster
```julia
julia> G = tf(ssrand(2,2,6));

julia> using BenchmarkTools

julia> @btime poles(G); # New implementation
  99.067 μs (1288 allocations: 1.46 MiB)

julia> @btime poles(zpk(G)); # Old implementation
  167.226 μs (1372 allocations: 166.44 KiB)
```