### PR TITLE
test: update github actions CI and run tests on `LTS` and `pre`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     permissions: # needed for julia-actions/cache to delete old caches
       actions: write
       contents: read
-    continue-on-error: ${{ matrix.version == 'pre' }} # the CI badge will still pass if 'pre' fails
+    continue-on-error: ${{ matrix.version == 'pre' || matrix.version == 'nightly' }} # the CI badge will still pass if 'pre' or 'nightly' fails
     strategy:
       fail-fast: false
       matrix:
@@ -53,7 +53,6 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         env:
           GROUP: ${{ matrix.group }}
-        # continue-on-error: ${{ matrix.version == 'nightly' }} # Allow nightly to fail and workflow still count as completed
       - uses: julia-actions/julia-processcoverage@v1
         with:
           directories: src,lib/ControlSystemsBase/src,lib/ControlSystemsBase/ext

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,22 +16,30 @@ jobs:
     name: Julia ${{ matrix.group }} - ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }} 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 50
+    permissions: # needed for julia-actions/cache to delete old caches
+      actions: write
+      contents: read
+    continue-on-error: ${{ matrix.version == 'pre' }} # the CI badge will still pass if 'pre' fails
     strategy:
       fail-fast: false
       matrix:
-        version: ['1']
+        version:
+          - 'lts' # long-term support release
+          - '1'   # latest stable 1.x release
+          - 'pre' # latest stable prerelease
+          # - 'nightly' # commented since too noisy + 'pre' allows testing upcoming versions
         os: [ubuntu-latest]
         arch: [x64]
         group:
           - ControlSystems
           - ControlSystemsBase
     steps:
-      - uses: actions/checkout@v3
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
         env:
           cache-name: cache-artifacts
         with:
@@ -50,7 +58,7 @@ jobs:
         with:
           directories: src,lib/ControlSystemsBase/src,lib/ControlSystemsBase/ext
         if: ${{ matrix.version == '1' }}
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         if: ${{ matrix.version == '1' }}
         with:
           file: lcov.info


### PR DESCRIPTION
Trying to:
- closes #975 (it theoretically improves the performance of testing on CI with caching of testing dependencies)
- closes #987 (the part about testing on `pre`: it can be useful for preemptive testing and is less noisy than `nightly`)

Since `pre` is not intended for normal julia users (i.e. non-package developers), I don't think it should impact the CI badge.