### PR TITLE
Improved example of creating a transfer function

### DIFF
--- a/docs/src/man/creating_systems.md
+++ b/docs/src/man/creating_systems.md
@@ -21,14 +21,14 @@ tf(num, den, Ts) # Discrete-time system
 where `num` and `den` are the polynomial coefficients of the numerator and denominator of the polynomial and `Ts`, if provided, is the sample time for a discrete-time system.
 #### Example:
 ```jldoctest
-tf([1.0],[1,2,1])
+tf([1.0],[1,2,3])
 
 # output
 
 TransferFunction{Continuous, ControlSystemsBase.SisoRational{Float64}}
         1.0
 -------------------
-1.0s^2 + 2.0s + 1.0
+1.0s^2 + 2.0s + 3.0
 
 Continuous-time transfer function model
 ```


### PR DESCRIPTION
The example of creating a transfer function now contains an asymmetric vector of coefficients, from which it is clear whether the coefficients correspond to the ascending or descending powers.

Fixes #1052.