### PR TITLE
Fix _default_dt for DelayLtiSystem (closes #544)

### DIFF
--- a/lib/ControlSystemsBase/src/delay_systems.jl
+++ b/lib/ControlSystemsBase/src/delay_systems.jl
@@ -80,16 +80,15 @@ end
 # Again we have to do something for default vectors, more or less a copy from timeresp.jl
 function _default_dt(sys::DelayLtiSystem)
     if !isstable(sys.P.P)
-        return 0.05   # Something small
-    else
-        ps = poles(sys.P.P)
-        r = minimum([abs.(real.(ps));0]) # Find the fastest pole of sys.P.P
-        r = min(r, minimum([sys.Tau;0])) # Find the fastest delay
-        if r == 0.0
-            r = 1.0
-        end
-        return 0.07/r
+        return 0.05
     end
+    ps = poles(sys.P.P)
+    ω_max = isempty(ps) ? 0.0 : maximum(abs, ps)
+    τ_min = minimum((τ for τ in sys.Tau if τ > 0); init = Inf)
+    dt_pole  = ω_max > 0      ? round(1/(12*ω_max), sigdigits=2) : Inf
+    dt_delay = isfinite(τ_min) ? round(τ_min/12,    sigdigits=2) : Inf
+    dt = min(dt_pole, dt_delay)
+    return isfinite(dt) ? dt : 0.05
 end
 
 

--- a/test/test_delay_timeresp.jl
+++ b/test/test_delay_timeresp.jl
@@ -133,3 +133,14 @@ P = 1 / (0.85*s + 1)*exp(-0.14*s)
 res = step(P, 5)
 @test res.t[end] > 4.5
 @test length(res.y) > 30
+
+# Issue #544: step(delay(τ)) with small τ used to throw BoundsError after
+# `dt <= dtmin` from the DDE solver; default dt now adapts to τ.
+let sys = delay(0.01)
+    res = step(sys)
+    @test res.t[2] - res.t[1] ≤ 0.01/5
+    @test res.t[end] > 0.1
+    @test all(isfinite, res.y)
+    @test res.y[1] ≈ 0 atol = 1e-8
+    @test res.y[end] ≈ 1 atol = 1e-3
+end


### PR DESCRIPTION
## Summary

- Fix `_default_dt(::DelayLtiSystem)` so the default time-vector `dt` actually adapts to the system's poles and delays. Previously the function always returned `0.07` because two `[…; 0]` constructs collapsed `r` to `0`, which then fell back to `r = 1.0`.
- Add a regression test for #544: `step(delay(0.01))` now uses `dt ≈ 0.00083`, ran past the delay, and produces `y[end] ≈ 1`.
- Closes #544.

The new heuristic mirrors `_default_dt(::LTISystem)`: take the fastest pole magnitude `ω_max` and the smallest positive delay `τ_min`, pick the more demanding of `1/(12·ω_max)` and `τ_min/12`.

### Context

Issue #544 was originally about `step(delay(0.01))` failing with `dt <= dtmin` and a `BoundsError`. The error itself was resolved in #690 (2022) via `force_dtmin=true`, but the root-cause heuristic was never fixed — so `step(delay(0.01))` ran without erroring while sampling far too coarsely to resolve the delay. This PR fixes that.

While verifying the fix I hit an apparently-unrelated upstream issue: `MethodOfSteps(Tsit5())` + neutral DDE + `SavingCallback` errors out specifically at `dt = 0.014` for the existing test system `1/(0.85s+1)·exp(-0.14s)`, while neighbouring `dt` values succeed. Reported as [SciML/OrdinaryDiffEq.jl#3636](https://github.com/SciML/OrdinaryDiffEq.jl/issues/3636). The new heuristic uses `/12` (matching the LTI version) rather than `/10`, which happens to land on `0.012` instead of `0.014` and sidesteps the upstream bug for now.

## Test plan

- [x] `delay_timeresp` testset passes (33/33, including the new regression test)
- [x] `timeresp` testset passes (no regressions)
- [x] Pre-existing `step(1/(0.85s+1)*exp(-0.14s), 5)` test still passes (length 417, dt 0.012)
- [x] `step(delay(0.01))` now returns `y[end] ≈ 1` with `dt ≈ 0.00083`