### PR TITLE
Use `oneunit` in remaining tf/ss/zpk type-promotion sites

### DIFF
--- a/lib/ControlSystemsBase/src/matrix_comps.jl
+++ b/lib/ControlSystemsBase/src/matrix_comps.jl
@@ -474,7 +474,7 @@ function _infnorm_two_steps_dt(sys::AbstractStateSpace, normtype::Symbol, tol=1e
     on_unit_circle = z -> abs(abs(z) - 1) < approxcirc # Helper fcn for readability
 
     T = promote_type(real(numeric_type(sys)), Float64, typeof(true/sys.Ts))
-    Tw = typeof(one(T)/sys.Ts)
+    Tw = typeof(oneunit(T)/sys.Ts)
 
     if sys.nx == 0  # static gain
         return (T(opnorm(sys.D)), Tw(0))

--- a/lib/ControlSystemsBase/src/types/SisoTfTypes/SisoRational.jl
+++ b/lib/ControlSystemsBase/src/types/SisoTfTypes/SisoRational.jl
@@ -39,7 +39,7 @@ Base.zero(f::SisoRational) = zero(typeof(f))
 isproper(f::SisoRational) = (length(f.num) <= length(f.den))
 
 function minreal(sys::SisoRational{T}, eps::Real=sqrt(eps())) where T
-    T2 = typeof(zero(T)/one(T))
+    T2 = typeof(oneunit(T)/oneunit(T))
     return convert(SisoRational{T2}, minreal(convert(SisoZpk,sys), eps))
 end
 

--- a/lib/ControlSystemsBase/src/types/conversion.jl
+++ b/lib/ControlSystemsBase/src/types/conversion.jl
@@ -291,7 +291,7 @@ function convert(::Type{TransferFunction{TE,SisoRational{T}}}, sys::AbstractStat
     TransferFunction{TE,SisoRational{T}}(matrix, TE(sys.timeevol))
 end
 function convert(::Type{TransferFunction{TE1,SisoRational}}, sys::StateSpace{TE2,T0}) where {TE1,TE2,T0<:Number}
-    T = typeof(one(T0)/one(T0))
+    T = typeof(oneunit(T0)/oneunit(T0))
     convert(TransferFunction{TE1,SisoRational{T}}, sys)
 end
 
@@ -307,7 +307,7 @@ function convert(::Type{TransferFunction{TE,SisoZpk{T,TR}}}, sys::AbstractStateS
 end
 function convert(::Type{TransferFunction{TE1,SisoZpk}}, sys::AbstractStateSpace{TE2}) where {TE1,TE2}
     T0 = numeric_type(sys)
-    T = typeof(one(T0)/one(T0))
+    T = typeof(oneunit(T0)/oneunit(T0))
     convert(TransferFunction{TE1,SisoZpk{T,complex(T)}}, sys)
 end
 
@@ -335,7 +335,7 @@ Implements: "An accurate and efficient algorithm for the computation of the char
 """
 function charpoly(A::AbstractMatrix{T}) where {T}
     N = size(A, 1)
-    TT = typeof(one(T)/one(T))
+    TT = typeof(oneunit(T)/oneunit(T))
     poly_factors = vec(ones(TT, N+1))
     if N <= 0
         return poly_factors

--- a/lib/ControlSystemsBase/src/types/zpk.jl
+++ b/lib/ControlSystemsBase/src/types/zpk.jl
@@ -65,7 +65,7 @@ zpk(k::Real, Ts::TimeEvolution) = zpk(eltype(k)[], eltype(k)[], k, Ts)
 zpk(sys::AbstractStateSpace) = zpk(zpkdata(sys)..., timeevol(sys))
 
 function zpk(G::TransferFunction{TE,S}) where {TE<:TimeEvolution,T0, S<:SisoTf{T0}}
-    T = typeof(one(T0)/one(T0))
+    T = typeof(oneunit(T0)/oneunit(T0))
     convert(TransferFunction{TE,SisoZpk{T, complex(T)}}, G)
 end
 


### PR DESCRIPTION
## Summary
- Completes the fix started in b394b96b. Measurements.jl deliberately defines `Base.one(::Type{Measurement{T}}) = one(T)`, so `one(Measurement{Float64}) === 1.0::Float64`. Five conversion sites still inferred the result element type via `typeof(one(T0)/one(T0))` / `typeof(zero(T0)/one(T0))`, which collapsed `Measurement{Float64}` to `Float64` and triggered the `MethodError: no method matching Float64(::Measurement{Float64})` reported in #1027 along the `tf → zpk`, `ss → tf`, `ss → zpk`, `minreal`, and `charpoly` paths.
- Switched the remaining sites to `typeof(oneunit(T)/oneunit(T))`, matching the existing fix in `convert(::Type{StateSpace}, G::TransferFunction)`. Behavior for `Int`/`Float64`/`BigFloat`/etc. is unchanged (`oneunit/oneunit` reduces to `one/one` when `one(T) isa T`).
- Sites touched: `types/conversion.jl` (×3: ss→TF/SisoRational, ss→TF/SisoZpk, `charpoly`), `types/zpk.jl` (tf→zpk), `types/SisoTfTypes/SisoRational.jl` (`minreal`), `matrix_comps.jl` (`_infnorm_two_steps_dt`, for consistency).

Closes #1027 to the extent it's a ControlSystems issue. (`zpk` and `tf(::ss{Measurement})` may still fail downstream inside `Polynomials.roots` / `LinearAlgebra.hessenberg`, which need BLAS-able elements — separate upstream limitations.)

## Test plan
- [x] `lib/ControlSystemsBase` test suite: 21146 pass, 6 broken (unchanged from master).
- [x] `RobustAndOptimalControl.jl` test suite (extra promotion coverage): 1357 pass, 6 broken (unchanged).
- [x] Issue #1027 reproducer: `ss(P)` now returns `StateSpace{Continuous, Measurement{Float64}}` with elements preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)