### PR TITLE
Fix marginplot variable assignment for >5 phase margins

### DIFF
--- a/lib/ControlSystemsBase/src/plotting.jl
+++ b/lib/ControlSystemsBase/src/plotting.jl
@@ -810,8 +810,8 @@ marginplot
                 if length(pm) > 5
                     @warn "Only showing \"smallest\" 5 out of $(length(pm)) phase margins"
                     idx = sortperm(pm)
-                    wgm = wpm[idx[1:5]]
-                    gm = pm[idx[1:5]]
+                    wpm = wpm[idx[1:5]]
+                    pm = pm[idx[1:5]]
                 end
                 if _PlotScale == "dB"
                     mag = 20 .* log10.(1 ./ gm)


### PR DESCRIPTION
:heavy_check_mark: 
## Summary
When a system has more than 5 phase margins, the code that filters to the 5 smallest assigned the filtered values to `wgm`/`gm` (the gain-margin display variables) instead of `wpm`/`pm`. This silently overwrote gain-margin data with phase-margin data on the plot.

Likely copy-paste from the analogous block immediately above (which correctly filters gain margins).

## Test plan
- [ ] Plot `marginplot` for a system with more than 5 phase margins and verify the gain-margin annotations are now correct.
- [ ] Existing `test_plots.jl` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)