### PR TITLE
Fix isstable for discrete Dual state-space to check eigenvalues

### DIFF
--- a/lib/ControlSystemsBase/src/types/StateSpace.jl
+++ b/lib/ControlSystemsBase/src/types/StateSpace.jl
@@ -233,7 +233,7 @@ function isstable(sys::StateSpace{Continuous, <:ForwardDiff.Dual})
     all(real.(eigvals(ForwardDiff.value.(sys.A))) .< 0)
 end
 function isstable(sys::StateSpace{<:Discrete, <:ForwardDiff.Dual})
-    all(abs.(ForwardDiff.value.(sys.A)) .< 1)
+    all(abs.(eigvals(ForwardDiff.value.(sys.A))) .< 1)
 end
 
 isrational(::AbstractStateSpace) = true


### PR DESCRIPTION
## Summary
The `isstable` specialization for `StateSpace{<:Discrete, <:ForwardDiff.Dual}` checked `|A[i,j]| < 1` element-wise rather than `|λ(A)| < 1`. This is unrelated to discrete-time stability.

Example counter-example before the fix:
```julia
A = 0.9 * ones(2,2)   # entries all < 1
# eigenvalues: 0.0, 1.8 → not stable, but old code returned true
```

The continuous-time `Dual` specialization immediately above already uses `eigvals` correctly; this aligns the discrete one with it.

## Test plan
- [ ] Construct a discrete Dual state-space with entries < 1 but spectral radius > 1, confirm `isstable` returns `false`.
- [ ] Existing tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)