### PR TITLE
Fix pid_tf coefficients for Ki=0 with first-order derivative filter

### DIFF
--- a/lib/ControlSystemsBase/src/pid_design.jl
+++ b/lib/ControlSystemsBase/src/pid_design.jl
@@ -68,7 +68,7 @@ function pid_tf(param_p, param_i, param_d=zero(typeof(param_p)); form=:standard,
     else
         if Ki == 0
             if filter_order == 1
-                tf([Kd*Tf + Kd, Kd], [Tf, 1])
+                return tf([Kd + Kp*Tf, Kp], [Tf, 1])
             else
                 return tf([Kd, Kp], [Tf^2/(4d^2), Tf, 1])
             end

--- a/lib/ControlSystemsBase/test/test_pid_design.jl
+++ b/lib/ControlSystemsBase/test/test_pid_design.jl
@@ -77,6 +77,13 @@ Ctf = pid(1.1, 1.2, 0, Tf=0.1, filter_order=1)
 Css = pid(1.1, 1.2, 0, Tf=0.1, filter_order=1, state_space=true)
 @test freqresptest(Ctf, Css) < 1e-10
 
+# Regression for #1058: pid_tf for Ki=0 and filter_order=1 used to emit
+# tf([Kd*Tf + Kd, Kd], [Tf, 1]) — Kp dropped and replaced with Kd.
+Ctf = pid(1.1, 0, 1.5, Tf=0.1, filter_order=1, form=:parallel)
+Css = pid(1.1, 0, 1.5, Tf=0.1, filter_order=1, form=:parallel, state_space=true)
+@test freqresptest(Ctf, Css) < 1e-10
+@test Ctf ≈ tf([1.5 + 1.1*0.1, 1.1], [0.1, 1])
+
 # bodeplot([Ctf, Css])
 
 


### PR DESCRIPTION
## Summary
For `pid_tf` with `Ki = 0`, first-order derivative filter, and a non-`nothing` `Tf`, the returned transfer function should be

```
C(s) = Kp + Kd*s / (Tf*s + 1) = ((Kp*Tf + Kd)*s + Kp) / (Tf*s + 1)
```

i.e. numerator `[Kp*Tf + Kd, Kp]`. The code instead produced `[Kd*Tf + Kd, Kd]` — `Kp` was dropped entirely and substituted with `Kd`. The returned controller therefore contained no proportional term.

The adjacent branch (`Ki != 0`, `filter_order == 1`) uses the correct form `[Kd + Kp*Tf, Ki*Tf + Kp, Ki]`; collapsing that for `Ki = 0` agrees with the fix.

## Test plan
- [ ] Compare `pid_tf(Kp, 0, Kd; Tf, filter_order=1)` against the analytical transfer function above (Kp=2, Kd=0.5, Tf=0.1).
- [ ] Existing tests in `test_pid_design.jl` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)