### PR TITLE
Fix stepinfo crash when response does not reach risetime thresholds

### DIFF
--- a/lib/ControlSystemsBase/src/plotting.jl
+++ b/lib/ControlSystemsBase/src/plotting.jl
@@ -175,18 +175,20 @@ end
         label := @sprintf("Final value: %.3f", si.yf)
         [si.yf]
     end
-    @series begin
-        linestyle := :solid
-        linewidth --> 2
-        color --> 2
-        label := @sprintf("Rise time: %.3f", si.risetime)
-        si.res.t[si.i10:si.i90], si.res.y[1, si.i10:si.i90]
-    end
-    @series begin
-        color --> 2
-        seriestype := :vline
-        label := @sprintf("Rise time threshold: %.1f%%-%.1f%%", 100si.risetime_th[1], 100si.risetime_th[2])
-        [si.res.t[si.i10], si.res.t[si.i90]]
+    if si.i10 > 0 && si.i90 > 0
+        @series begin
+            linestyle := :solid
+            linewidth --> 2
+            color --> 2
+            label := @sprintf("Rise time: %.3f", si.risetime)
+            si.res.t[si.i10:si.i90], si.res.y[1, si.i10:si.i90]
+        end
+        @series begin
+            color --> 2
+            seriestype := :vline
+            label := @sprintf("Rise time threshold: %.1f%%-%.1f%%", 100si.risetime_th[1], 100si.risetime_th[2])
+            [si.res.t[si.i10], si.res.t[si.i90]]
+        end
     end
     @series begin
         color --> 3

--- a/lib/ControlSystemsBase/src/timeresp.jl
+++ b/lib/ControlSystemsBase/src/timeresp.jl
@@ -550,7 +550,14 @@ function stepinfo(res::SimResult; y0 = nothing, yf = nothing, settling_th = 0.02
     op = direction == 1 ? (>) : (<)
     i10 = findfirst(op.(y, y0 + risetime_th[1] * stepsize * direction))
     i90 = findfirst(op.(y, y0 + risetime_th[2] * stepsize * direction))
-    risetime = res.t[i90] - res.t[i10]
+    if i10 === nothing || i90 === nothing
+        @warn "Response did not reach the requested risetime threshold(s) within the simulation window"
+        i10 = i10 === nothing ? 0 : i10
+        i90 = i90 === nothing ? 0 : i90
+        risetime = oftype(float(res.t[1]), NaN)
+    else
+        risetime = res.t[i90] - res.t[i10]
+    end
     StepInfo(y0, yf, stepsize, peak, peaktime, overshoot, lowerpeak, lowerpeakind, undershoot, settlingtime, settlingtimeind, risetime, i10, i90, res, settling_th, risetime_th)
 end
 


### PR DESCRIPTION
## Summary
`stepinfo` indexed `res.t[i10]`/`res.t[i90]` without checking whether `findfirst` actually found the rise-time crossings. When the response never reaches the lower or upper threshold within the simulation window, `findfirst` returns `nothing` and the subsequent indexing crashes with `MethodError`.

This PR:
- Sets `i10`/`i90` to `0` (sentinel meaning "not reached") and `risetime = NaN` when either threshold is not crossed, plus emits a warning.
- Guards the `stepinfoplot` recipe to skip the rise-time series when either index is zero (so the plot still renders).

## Test plan
- [ ] `stepinfo(step(tf(1,[1,0,1]), 5))` (an oscillator that doesn't settle, with too-short horizon) no longer throws.
- [ ] `plot(stepinfo(...))` on the same input renders without error.
- [ ] Existing `test_timeresp.jl` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)