### PR TITLE
Fix Nyquist frequency and the P(s)Z(s) exactness claim in the ZoH example

### DIFF
--- a/docs/src/examples/zoh.md
+++ b/docs/src/examples/zoh.md
@@ -24,13 +24,17 @@ Z = (1 - delay(Ts))/(Ts*s) # The transfer function of the ZoH operator
 Pd = c2d(P, Ts) # Discrete-time system obtained by ZoH sampling
 Pz = P*Z # The continuous-time version of the discrete-time system
 
-wd = exp10.(-2:0.01:log10(2*0.5))
+wd = exp10.(LinRange(-2, log10(π/Ts), 200)) # Up to the Nyquist frequency
 bodeplot(P, wd, lab="\$P(s)\$")
 bodeplot!(Pz, wd, lab="\$P(s)Z(s)\$")
 bodeplot!(Pd, wd, lab="\$P_d(z)\$ (ZoH sampling)", l=:dash)
-vline!([0.5 0.5], l=(:black, :dash), lab="Nyquist freq.", legend=:bottomleft)
+vline!([π/Ts π/Ts], l=(:black, :dash), lab="Nyquist freq.", legend=:bottomleft)
 ```
-The frequency response of `Pz` ``= P(s) Z(s)`` matches that of ``P_d(z)`` exactly, but these two differ from the frequency response of the original ``P(s)`` due to the ZoH operator.
+Both `Pz` ``= P(s)Z(s)`` and ``P_d(z)`` differ from the frequency response of the original ``P(s)`` due to the ZoH operator. `Pz` and ``P_d`` agree closely over the lower part of the frequency axis, but they are *not* equal: sampling folds the response at all frequencies ``\omega + k\omega_s`` down onto ``\omega``, so the exact relation between them is the aliasing sum [^CCS]
+```math
+P_d(e^{i\omega T_s}) = \sum_{k=-\infty}^{\infty} Z\big(i(\omega + k\omega_s)\big) \, P\big(i(\omega + k\omega_s)\big), \qquad \omega_s = 2\pi/T_s
+```
+of which ``P(s)Z(s)`` is the ``k = 0`` term alone. The folded terms are negligible as long as ``P`` has rolled off well before ``\omega_s``, which is why the two curves are indistinguishable at low frequencies, but they diverge visibly as ``\omega`` approaches the Nyquist frequency ``\pi/T_s``. When an accurate continuous-time equivalent is required near or above the Nyquist frequency, use [`d2c_exact`](@ref) instead, see [Discrete to continuous](@ref) below.
 
 The step response of `Pz` ``= P(s) Z(s)`` matches the discrete output of ``P_d(z)`` delayed by half the sample time
 ```@example zoh
@@ -56,8 +60,10 @@ plot!(t_shift, resPd.y[:], lab="Pd shifted", m=:o)
 ```
 
 With a _continuous_ input signal, the result is different,
-after the initial transient, the output of `Pz` matches that of `Pd` exactly
-(try plotting with the plotly() backend and zoom in at the end)
+after the initial transient, the output of `Pz` closely matches that of `Pd`
+(try plotting with the plotly() backend and zoom in at the end). The match here is close but
+not exact — the residual difference is the aliasing contribution discussed above, and it grows
+as the frequency of the input approaches the Nyquist frequency.
 ```@example zoh
 Tf = 100
 ufun = (x,t)->[sin(2pi*t/5)]
@@ -82,7 +88,7 @@ Pc = d2c(Pd)
 bodeplot(Pd, wd, lab="\$P_d(z)\$")
 bodeplot!(Pdc, wd, lab="\$P_d(s)\$ (exact translation)", l=:dash)
 bodeplot!(Pc, wd, lab="\$P_d(s)\$ (inverse ZoH sampling)")
-vline!([0.5 0.5], l=(:black, :dash), lab="Nyquist freq.", legend=:bottomleft)
+vline!([π/Ts π/Ts], l=(:black, :dash), lab="Nyquist freq.", legend=:bottomleft)
 ```
 We see that the translation of the discrete-time system to continuous time using the standard inverse ZoH sampling (`d2c(Pd)`) is not accurate for frequencies close to and above the Nyquist frequency. The translation using exact method (`d2c_exact(Pd)`) matches the frequency response of the discrete-time system exactly over the entire frequency axis.
 


### PR DESCRIPTION
Draft. Three related fixes to `docs/src/examples/zoh.md`.

## 1. The Nyquist frequency marker was off by a factor of 2π

Both Bode plots on the page draw the marker with `vline!([0.5 0.5], lab="Nyquist freq.")`. The `bodeplot` x-axis is rad/s (`hz=false` by default), so with `Ts = 1` the Nyquist frequency is `π/Ts ≈ 3.14` rad/s. `0.5` is that frequency in Hz.

The page was already internally inconsistent about this — further down it says *"(Nyquist frequency is π rad/s)"*, and `_default_freq_vector` in `lib/ControlSystemsBase/src/freqresp.jl` uses `log10(π/sys.Ts)` with the comment "Draw up to Nyquist frequency for discrete systems".

Both markers now use `π/Ts`.

## 2. `P(s)Z(s)` does not match `P_d(z)` exactly

The first plot only extended to `ω = 1` rad/s — 0.32× the actual Nyquist frequency. Over that range the two agree to 0.4%, invisible on a log-magnitude plot, and the text concluded they *"match exactly"*.

They don't. ZoH sampling folds the response at every `ω + kω_s` down onto `ω`, so the exact relation is the aliasing sum

```
P_d(exp(iωTs)) = Σ_k  Z(i(ω + kω_s)) · P(i(ω + kω_s)),   ω_s = 2π/Ts
```

and `P(s)Z(s)` is only the `k = 0` term. Verified against `c2d` to ~1e-14 relative error. For this page's `P = tf(0.1,[1,0.1,0.1])`, `Ts = 1`, the `k = 0` truncation error is:

| ω | vs. Nyquist | error of `P·Z` |
|---|---|---|
| 1.0 (old plot limit) | 0.32× | 0.4% |
| 1.22 | 0.39× | 1% |
| 2.0 | 0.64× | 10% |
| 2.985 | 0.95× | 269% |

The frequency axis now runs up to the Nyquist frequency, which makes the divergence plainly visible, and the text states the aliasing sum and points to `d2c_exact` for work near Nyquist.

Both plots become considerably more informative as a side effect — in the *Discrete to continuous* plot the marker now lands exactly on the fold, with the aliased image above it, which is what that section's prose is actually describing.

## 3. Same overstatement in the time domain

The continuous-sinusoid comparison said the output of `Pz` *"matches that of `Pd` exactly"*. At the input frequency used there the steady-state amplitudes differ by about 1% — the same aliasing contribution. Softened, and phrased without a hard-coded number so it does not go stale if the input frequency is changed.

## Left alone

The `d2c_exact` claim in the same file is **correct** and unchanged: it reproduces the discrete frequency response to ~1e-14 across the whole axis including above Nyquist, since it is an algebraic `z^{-1} = e^{-sTs}` substitution.

## Verification

Both edited `@example` blocks were executed in a real session with `ControlSystems` + `Plots` and render as expected; the aliasing sum, the truncation errors, and the `d2c_exact` exactness were each checked numerically. I did **not** run a full `docs/make.jl` build (that environment needs Ipopt/GCMAES/etc.), but the only new Documenter construct is a same-page section `@ref`, a pattern already used elsewhere in these docs, and `makedocs` here sets `warnonly = [:missing_docs, :cross_references]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VaQczXaXuF3KW5Lu9yMMD8
