### PR TITLE
Fix docs build: import OptimizationFunction and AutoForwardDiff explicitly

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 ControlSystemIdentification = "3abffc1c-5106-53b7-b354-a47bfc086282"
 ControlSystems = "a6e380b2-a6ca-5380-bf3e-84a91bcd477e"
@@ -15,5 +16,6 @@ MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
 OptimizationGCMAES = "6f0a0517-dbc2-4a7a-8a20-99ae7f27e911"
 OptimizationIpopt = "43fad042-7963-4b32-ab19-e2a4f9a67124"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TrajectoryLimiters = "9792e600-fe43-4e4e-833b-462f466b8006"

--- a/docs/src/examples/automatic_differentiation.md
+++ b/docs/src/examples/automatic_differentiation.md
@@ -110,6 +110,8 @@ The constraint function `constraints` enforces the peak of the sensitivity funct
 ```@example autodiff
 using Statistics, LinearAlgebra
 using OptimizationIpopt
+using SciMLBase: OptimizationFunction, OptimizationProblem, solve
+using ADTypes: AutoForwardDiff
 
 function plot_optimized(P, params, res, systems)
     fig = plot(layout=(1,3), size=(1200,400), bottommargin=2Plots.mm)
@@ -181,7 +183,7 @@ solver = IpoptOptimizer(;
     ),
 )
 
-fopt = OptimizationFunction(cost, OptimizationIpopt.AutoForwardDiff(); cons=constraints)
+fopt = OptimizationFunction(cost, AutoForwardDiff(); cons=constraints)
 
 prob = OptimizationProblem(fopt, params, (P, systemspid);
     lb    = fill(-10.0, length(params)),


### PR DESCRIPTION
The Documentation workflow has been failing on master since July 31 and on open PRs since.

## Cause

The current failure is in `docs/src/examples/automatic_differentiation.md`:

```
UndefVarError: `OptimizationFunction` not defined in `Main.__atexample__named__autodiff`
```

OptimizationIpopt v1.4 (SciML/Optimization.jl#1286, merged 2026-08-02) curated its public API and no longer re-exports the Optimization API. The example only did `using OptimizationIpopt`, so `OptimizationFunction`, `OptimizationProblem`, `solve` and `OptimizationIpopt.AutoForwardDiff` are no longer available.

The earlier July failure on master was a different, transient issue: DelayDiffEq v6.1.0 resolved together with an incompatible OrdinaryDiffEqCore v4.11.0, making every `lsim` on a delay system throw. Newer registry versions resolve compatibly now, and those pages pass in today's CI runs and locally.

## Fix

Import the missing names from the packages that define them, without loading Optimization.jl:

- `using SciMLBase: OptimizationFunction, OptimizationProblem, solve`
- `using ADTypes: AutoForwardDiff`

Both packages are already dependencies of OptimizationIpopt, so this adds nothing to the load time. They are added to `docs/Project.toml` so they can be loaded directly.

## Verification

Instantiated the docs environment the same way the workflow does (resolves to OptimizationIpopt v1.4.1, SciMLBase v3.53.1, ADTypes v1.24.0) and ran every `@example` block of `automatic_differentiation.md`, `delay_systems.md`, `smith_predictor.md` and `zoh.md` in order. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)